### PR TITLE
fix: init segment change without discontinuity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ coverage/
 /dist
 /netlify
 /api-docs
+
+hls.js*.tgz

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "hls.js",
+  "version": "0.14.17-doris.4",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -205,13 +205,17 @@ class AudioStreamController extends BaseStreamController {
             // Ensure we find a fragment which matches the continuity of the video track
             frag = findFragWithCC(fragments, this.videoTrackCC);
           }
-          if (trackDetails.live && frag.loadIdx && frag.loadIdx === this.fragLoadIdx) {
+          if (trackDetails.live && frag && frag.loadIdx && frag.loadIdx === this.fragLoadIdx) {
             // we just loaded this first fragment, and we are still lagging behind the start of the live playlist
             // let's force seek to start
             const nextBuffered = bufferInfo.nextStart ? bufferInfo.nextStart : start;
             logger.log(`no alt audio available @currentTime:${this.media.currentTime}, seeking @${nextBuffered + 0.05}`);
             this.media.currentTime = nextBuffered + 0.05;
             return;
+          } else {
+            if (trackDetails.live && !frag) {
+              logger.log('skipping nudge, no fragment is available yet.');
+            }
           }
         } else {
           let foundFrag;

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -45,7 +45,7 @@ class DemuxerInline {
     }
   }
 
-  push (data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS) {
+  push (data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS, initSegmentChange) {
     if ((data.byteLength > 0) && (decryptdata != null) && (decryptdata.key != null) && (decryptdata.method === 'AES-128')) {
       let decrypter = this.decrypter;
       if (decrypter == null) {
@@ -56,14 +56,14 @@ class DemuxerInline {
       decrypter.decrypt(data, decryptdata.key.buffer, decryptdata.iv.buffer, (decryptedData) => {
         const endTime = now();
         this.observer.trigger(Event.FRAG_DECRYPTED, { stats: { tstart: startTime, tdecrypt: endTime } });
-        this.pushDecrypted(new Uint8Array(decryptedData), decryptdata, new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS);
+        this.pushDecrypted(new Uint8Array(decryptedData), decryptdata, new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS, initSegmentChange);
       });
     } else {
-      this.pushDecrypted(new Uint8Array(data), decryptdata, new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS);
+      this.pushDecrypted(new Uint8Array(data), decryptdata, new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS, initSegmentChange);
     }
   }
 
-  pushDecrypted (data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS) {
+  pushDecrypted (data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS, initSegmentChange) {
     let demuxer = this.demuxer;
     let remuxer = this.remuxer;
     if (!demuxer ||
@@ -105,7 +105,7 @@ class DemuxerInline {
       this.remuxer = remuxer;
     }
 
-    if (discontinuity || trackSwitch) {
+    if (discontinuity || trackSwitch || initSegmentChange) {
       demuxer.resetInitSegment(initSegment, audioCodec, videoCodec, duration);
       remuxer.resetInitSegment();
     }

--- a/src/demux/demuxer-worker.js
+++ b/src/demux/demuxer-worker.js
@@ -38,7 +38,7 @@ let DemuxerWorker = function (self) {
       forwardMessage('init', null);
       break;
     case 'demux':
-      self.demuxer.push(data.data, data.decryptdata, data.initSegment, data.audioCodec, data.videoCodec, data.timeOffset, data.discontinuity, data.trackSwitch, data.contiguous, data.duration, data.accurateTimeOffset, data.defaultInitPTS);
+      self.demuxer.push(data.data, data.decryptdata, data.initSegment, data.audioCodec, data.videoCodec, data.timeOffset, data.discontinuity, data.trackSwitch, data.contiguous, data.duration, data.accurateTimeOffset, data.defaultInitPTS, data.initSegmentChange);
       break;
     default:
       break;

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -102,6 +102,7 @@ class Demuxer {
     const trackSwitch = !(lastFrag && (frag.level === lastFrag.level));
     const nextSN = lastFrag && (frag.sn === (lastFrag.sn + 1));
     const contiguous = !trackSwitch && nextSN;
+    const initSegmentChange = !(lastFrag && (frag.initSegment === lastFrag.initSegment));
     if (discontinuity) {
       logger.log(`${this.id}:discontinuity detected`);
     }
@@ -110,14 +111,18 @@ class Demuxer {
       logger.log(`${this.id}:switch detected`);
     }
 
+    if (initSegmentChange) {
+      logger.log(`${this.id}:init segment change detected`);
+    }
+
     this.frag = frag;
     if (w) {
       // post fragment payload as transferable objects for ArrayBuffer (no copy)
-      w.postMessage({ cmd: 'demux', data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS }, data instanceof ArrayBuffer ? [data] : []);
+      w.postMessage({ cmd: 'demux', data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS, initSegmentChange }, data instanceof ArrayBuffer ? [data] : []);
     } else {
       let demuxer = this.demuxer;
       if (demuxer) {
-        demuxer.push(data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS);
+        demuxer.push(data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset, defaultInitPTS, initSegmentChange);
       }
     }
   }


### PR DESCRIPTION
## Description
- Avoid fatal errors caused by missing `loadIdx`.
- Detect init segment changes without discontinuities.

## To do
- [ ] Bump version?
