### PR TITLE
fix: ensure cues are displayed in correct order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.6",
+  "version": "0.14.17-doris.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.6",
+  "version": "0.14.17-doris.7",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/utils/cues.ts
+++ b/src/utils/cues.ts
@@ -56,26 +56,23 @@ export function newCue (track: TextTrack | null, startTime: number, endTime: num
         indent++;
       }
 
+      // VTTCue.line get's flakey when using controls, so let's now include line 13&14
+      // also, drop line 1 since it's to close to the top
+      if (navigator.userAgent.match(/Firefox\//)) {
+        cue.line = r + 1;
+      } else {
+        cue.line = (r > 7 ? r - 2 : r + 1);
+      }
+
       cue.id = generateCueId(cue.startTime, cue.endTime, cue.text);
-      cue.line = r + 1;
       cue.align = 'left';
       // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
       cue.position = Math.max(0, Math.min(100, 100 * (indent / 32)));
       result.push(cue);
-    }
-  }
-  if (track && result.length) {
-    // Sort bottom cues in reverse order so that they render in line order when overlapping in Chrome
-    result.sort((cueA, cueB) => {
-      if (cueA.line > 8 && cueB.line > 8) {
-        return cueB.line - cueA.line;
+      if (track) {
+        addCueToTrack(track, cue as any);
       }
-      return cueA.line - cueB.line;
-    });
-
-    result.forEach(cue => {
-      addCueToTrack(track, cue as any);
-    });
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Description

- Ensure cues are displayed in correct order (oldest -> latest). 

This uses v0.14.17 as a base for [`src/utils/cues.ts`]( https://github.com/DiceTechnology/hls.js/blob/v0.14.17/src/utils/cues.ts) and adds the duplicate cues prevention


## To do

- [x] Bump version
