### PR TITLE
fix: Audio Track selection & X-EXT-MAP order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.7",
+  "version": "0.14.17-doris.8",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -353,14 +353,6 @@ class AudioStreamController extends BaseStreamController {
     }
   }
 
-  findTrackById (tracks, trackId) {
-    for (const track of tracks) {
-      if (track.id === trackId) {
-        return track;
-      }
-    }
-  }
-
   onMediaAttached (data) {
     let media = this.media = this.mediaBuffer = data.media;
     this.onvseeking = this.onMediaSeeking.bind(this);

--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -1,6 +1,7 @@
 import Event from '../events';
 import TaskLoop from '../task-loop';
 import { logger } from '../utils/logger';
+import { findTrackById } from '../utils/findTrackById';
 import { ErrorTypes, ErrorDetails } from '../errors';
 
 /**
@@ -111,7 +112,7 @@ class AudioTrackController extends TaskLoop {
 
     logger.log(`audioTrack ${data.id} loaded`);
 
-    this.tracks[data.id].details = data.details;
+    findTrackById(this.tracks, data.id).details = data.details;
 
     // check if current playlist is a live playlist
     // and if we have already our reload interval setup
@@ -137,7 +138,7 @@ class AudioTrackController extends TaskLoop {
    * @param {*} data
    */
   onAudioTrackSwitched (data) {
-    const audioGroupId = this.tracks[data.id].groupId;
+    const audioGroupId = findTrackById(this.tracks, data.id).groupId;
     if (audioGroupId && (this.audioGroupId !== audioGroupId)) {
       this.audioGroupId = audioGroupId;
     }
@@ -211,7 +212,7 @@ class AudioTrackController extends TaskLoop {
    */
   _setAudioTrack (newId) {
     // noop on same audio track id as already set
-    if (this._trackId === newId && this.tracks[this._trackId].details) {
+    if (this._trackId === newId && findTrackById(this.tracks, this._trackId).details) {
       logger.debug('Same id as current audio-track passed, and track details available -> no-op');
       return;
     }
@@ -222,7 +223,7 @@ class AudioTrackController extends TaskLoop {
       return;
     }
 
-    const audioTrack = this.tracks[newId];
+    const audioTrack = findTrackById(this.tracks, newId);
 
     logger.log(`Now switching to audio-track index ${newId}`);
 
@@ -270,7 +271,7 @@ class AudioTrackController extends TaskLoop {
       return;
     }
 
-    const currentAudioTrack = this.tracks[this._trackId];
+    const currentAudioTrack = findTrackById(this.tracks, this._trackId);
 
     let name = null;
     if (currentAudioTrack) {
@@ -368,7 +369,7 @@ class AudioTrackController extends TaskLoop {
     this.clearInterval();
     this._trackId = newId;
     logger.log(`trying to update audio-track ${newId}`);
-    const audioTrack = this.tracks[newId];
+    const audioTrack = findTrackById(this.tracks, newId);
     this._loadTrackDetailsIfNeeded(audioTrack);
   }
 
@@ -381,7 +382,7 @@ class AudioTrackController extends TaskLoop {
 
     // Let's try to fall back on a functional audio-track with the same group ID
     const previousId = this._trackId;
-    const { name, language, groupId } = this.tracks[previousId];
+    const { name, language, groupId } = findTrackById(this.tracks, previousId);
 
     logger.warn(`Loading failed on audio track id: ${previousId}, group-id: ${groupId}, name/language: "${name}" / "${language}"`);
 
@@ -392,7 +393,7 @@ class AudioTrackController extends TaskLoop {
       if (this.trackIdBlacklist[i]) {
         continue;
       }
-      const newTrack = this.tracks[i];
+      const newTrack = findTrackById(this.tracks, i);
       if (newTrack.name === name) {
         newId = i;
         break;
@@ -404,7 +405,7 @@ class AudioTrackController extends TaskLoop {
       return;
     }
 
-    logger.log('Attempting audio-track fallback id:', newId, 'group-id:', this.tracks[newId].groupId);
+    logger.log('Attempting audio-track fallback id:', newId, 'group-id:', findTrackById(this.tracks, newId).groupId);
 
     this._setAudioTrack(newId);
   }

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -7,6 +7,7 @@ import EventHandler from '../event-handler';
 import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 import { isCodecSupportedInMp4 } from '../utils/codecs';
+import { findTrackById } from '../utils/findTrackById';
 import { addGroupId, computeReloadInterval } from './level-helper';
 
 let chromeOrFirefox;
@@ -482,7 +483,7 @@ export default class LevelController extends EventHandler {
   }
 
   onAudioTrackSwitched (data) {
-    const audioGroupId = this.hls.audioTracks[data.id].groupId;
+    const audioGroupId = findTrackById(this.hls.audioTracks, data.id).groupId;
 
     const currentLevel = this.hls.levels[this.currentLevelIndex];
     if (!currentLevel) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -14,6 +14,7 @@ import TimeRanges from '../utils/time-ranges';
 import { ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import { alignStream } from '../utils/discontinuities';
+import { findTrackById } from '../utils/findTrackById';
 import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
 import GapController, { MAX_START_GAP_JUMP } from './gap-controller';
 import BaseStreamController, { State } from './base-stream-controller';
@@ -1131,7 +1132,7 @@ class StreamController extends BaseStreamController {
 
   onAudioTrackSwitched (data) {
     let trackId = data.id,
-      altAudio = !!this.hls.audioTracks[trackId].url;
+      altAudio = !!findTrackById(this.hls.audioTracks, trackId).url;
     if (altAudio) {
       let videoBuffer = this.videoBuffer;
       // if we switched on alternate audio, ensure that main fragment scheduling is synced with video sourcebuffer buffered

--- a/src/loader/m3u8-parser.ts
+++ b/src/loader/m3u8-parser.ts
@@ -332,21 +332,20 @@ export default class M3U8Parser {
         }
         case 'MAP': {
           const mapAttrs = new AttrList(value1);
-          frag.relurl = mapAttrs.URI;
+          const init = new Fragment();
+          init.relurl = mapAttrs.URI;
           if (mapAttrs.BYTERANGE) {
-            frag.setByteRange(mapAttrs.BYTERANGE);
+            init.setByteRange(mapAttrs.BYTERANGE);
           }
-          frag.baseurl = baseurl;
-          frag.level = id;
-          frag.type = type;
-          frag.sn = 'initSegment';
+          init.baseurl = baseurl;
+          init.level = id;
+          init.type = type;
+          init.sn = 'initSegment';
           if (!level.initSegment) {
-            level.initSegment = frag;
+            level.initSegment = init;
           }
-          initSegment = new InitSegment(frag);
-          level.initSegments[frag.relurl] = initSegment;
-          frag = new Fragment();
-          frag.rawProgramDateTime = level.initSegment.rawProgramDateTime;
+          initSegment = new InitSegment(init);
+          level.initSegments[init.relurl] = initSegment;
           break;
         }
         default:

--- a/src/utils/findTrackById.js
+++ b/src/utils/findTrackById.js
@@ -1,0 +1,7 @@
+export const findTrackById = (tracks, trackId) => {
+  for (const track of tracks) {
+    if (track.id === trackId) {
+      return track;
+    }
+  }
+};

--- a/src/utils/findTrackById.js
+++ b/src/utils/findTrackById.js
@@ -1,7 +1,0 @@
-export const findTrackById = (tracks, trackId) => {
-  for (const track of tracks) {
-    if (track.id === trackId) {
-      return track;
-    }
-  }
-};

--- a/src/utils/findTrackById.ts
+++ b/src/utils/findTrackById.ts
@@ -1,0 +1,11 @@
+interface Track {
+  id: number;
+}
+
+export const findTrackById = (tracks: Track[], trackId: number) => {
+  for (const track of tracks) {
+    if (track.id === trackId) {
+      return track;
+    }
+  }
+};


### PR DESCRIPTION
## Bug fixes
- Fix audio track selection to be always by ID. This was causing an issue when alternate audio tracks are listed in different order to how they are referenced by the video streams.
- Fix m3u8 parsing when an init segment is located between an `#EXTINF` and the segment URL.