### PR TITLE
fix: Initial buffer failure due negative DTS alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.9",
+  "version": "0.14.17-doris.10",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -183,20 +183,15 @@ class AudioStreamController extends BaseStreamController {
 
         // When switching audio track, reload audio as close as possible to currentTime
         if (audioSwitch) {
-          if (trackDetails.live && !trackDetails.PTSKnown) {
-            logger.log('switching audiotrack, live stream, unknown PTS,load first fragment');
-            bufferEnd = 0;
-          } else {
-            bufferEnd = pos;
-            // if currentTime (pos) is less than alt audio playlist start time, it means that alt audio is ahead of currentTime
-            if (trackDetails.PTSKnown && pos < start) {
-              // if everything is buffered from pos to start or if audio buffer upfront, let's seek to start
-              if (bufferInfo.end > start || bufferInfo.nextStart) {
-                logger.log('alt audio track ahead of main track, seek to start of alt audio track');
-                this.media.currentTime = start + 0.05;
-              } else {
-                return;
-              }
+          bufferEnd = pos;
+          // if currentTime (pos) is less than alt audio playlist start time, it means that alt audio is ahead of currentTime
+          if (trackDetails.PTSKnown && pos < start) {
+            // if everything is buffered from pos to start or if audio buffer upfront, let's seek to start
+            if (bufferInfo.end > start || bufferInfo.nextStart) {
+              logger.log('alt audio track ahead of main track, seek to start of alt audio track');
+              this.media.currentTime = start + 0.05;
+            } else {
+              return;
             }
           }
         }

--- a/src/demux/mp4demuxer.js
+++ b/src/demux/mp4demuxer.js
@@ -300,7 +300,9 @@ class MP4Demuxer {
           let version = tfdt.data[tfdt.start];
           let baseMediaDecodeTime = readUint32(tfdt, 4);
           if (version === 0) {
-            MP4Demuxer.writeUint32(tfdt, 4, baseMediaDecodeTime - timeOffset * timescale);
+            baseMediaDecodeTime -= timeOffset * timescale;
+            baseMediaDecodeTime = Math.max(baseMediaDecodeTime, 0);
+            MP4Demuxer.writeUint32(tfdt, 4, baseMediaDecodeTime);
           } else {
             baseMediaDecodeTime *= Math.pow(2, 32);
             baseMediaDecodeTime += readUint32(tfdt, 8);


### PR DESCRIPTION
## Description
- Fixes playback failure caused by negative DTS values after syncing audio / video segments.
- Fixes issue with live streams occasionally starting at 0 seconds - causing playback stalls.

## To do
- [x] Bump version
