### PR TITLE
fix/start-up-audio-switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.11",
+  "version": "0.14.17-doris.12",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",


### PR DESCRIPTION
## Description

Add a tolerance to accepting audio segments for audio switching, as the times can be modified during the demuxing stage as part of the PTS alignment between audio / video.

This is meant to be a low impact fix only without many core changes.

Ideally fragment lookup should take the initPTS into account, so it doesn't rebuffer the wrong segment all the time.

## To do
- [ ] Bump version