### PR TITLE
feat: CMAF ID3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.12",
+  "version": "0.14.17-doris.13",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/demux/mp4demuxer.js
+++ b/src/demux/mp4demuxer.js
@@ -3,7 +3,7 @@
  */
 import { dummyTrack } from './dummy-demuxed-track';
 import { logger } from '../utils/logger';
-import { bin2str, findBox, parseVideoSegmentTextTrackSamples, readUint32 } from '../utils/mp4-tools';
+import { bin2str, findBox, parseId3TrackSamples, parseVideoSegmentTextTrackSamples, readUint32 } from '../utils/mp4-tools';
 import Event from '../events';
 
 const UINT32_MAX = Math.pow(2, 32) - 1;
@@ -346,7 +346,13 @@ class MP4Demuxer {
       }
     }
 
-    this.remuxer.remux(initData.audio, videoTrack, null, textTrack, startDTS, contiguous, accurateTimeOffset, data);
+    const id3Track = dummyTrack();
+    if (data && data.length && videoTrack) {
+      id3Track.samples = parseId3TrackSamples(data).filter(sample => sample && sample.timescale !== null);
+      id3Track.initPTS = initPTS;
+    }
+
+    this.remuxer.remux(initData.audio, videoTrack, id3Track, textTrack, startDTS, contiguous, accurateTimeOffset, data);
   }
 
   destroy () {}

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -613,3 +613,73 @@ export function discardEmulationPreventionBytes (data) {
 export function toUnsigned (value) {
   return value >>> 0;
 }
+
+const ID3_SCHEME_ID_URIS = [
+  'https://aomedia.org/emsg/ID3',
+  'https://developer.apple.com/streaming/emsg-id3',
+];
+
+export function readNullTerminatedString(buffer, offset): string {
+  let i = offset;
+
+  while (String.fromCharCode(buffer[i]) !== '\0' && i < buffer.byteLength) {
+    i++;
+  }
+
+  const val = new Uint8Array(buffer.subarray(offset, i));
+  return bin2str(val);
+}
+
+export function parseId3TrackSamples(data) {
+  const emsgs = findBox(data, ['emsg']);
+  return emsgs.map((emsg) => {
+    try {
+      const data = emsg.data.subarray(emsg.start, emsg.end);
+      let offset = 0;
+
+      const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+      const version = view.getUint8(offset);
+      if (version !== 1) {
+        return undefined;
+      }
+
+      // skip over 3 bytes of flags
+      offset += 4;
+      const timescale = view.getUint32(offset);
+      offset += 4;
+      const presentationTime = Number(view.getBigUint64(offset));
+      offset += 8;
+      const eventDuration = view.getUint32(offset);
+      offset += 4;
+      const id = view.getUint32(offset);
+      offset += 4;
+      const schemeIdUri = readNullTerminatedString(data, offset);
+      if (!ID3_SCHEME_ID_URIS.includes(schemeIdUri)) {
+        return undefined;
+      }
+
+      // skip over the null byte
+      offset += schemeIdUri.length + 1;
+      const value = readNullTerminatedString(data, offset);
+      // skip over the null byte
+      offset += value.length + 1;
+      // the rest is id3 payload
+      const messageData = new Uint8Array(
+        data.subarray(offset, data.byteLength)
+      );
+
+      return {
+        timescale,
+        pts: presentationTime,
+        dts: presentationTime,
+        duration: eventDuration !== 0xffffffff ? eventDuration : undefined,
+        id,
+        schemeIdUri,
+        value,
+        data: messageData,
+      };
+    } catch (e) {
+      return undefined;
+    }
+  });
+}


### PR DESCRIPTION
## Description

Adds CMAF ID3 support.

Fixes issue with CMAF SSAI streams where no ad countdown is visible and no impressions are sent due to lack of ID3 parsing.

Based on https://github.com/monyone/hls.js/tree/feature/cmaf-id3

## To do

- [x] Bump version