### PR TITLE
fix: download initial segment repeatedly

### DIFF
--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -363,6 +363,14 @@ export function mapFragmentIntersection(
       intersectionFn(oldFrag, newFrag);
     }
   }
+
+  const lastNewFrag = newFrags[end];
+  for (let i = end + 1; i < newFrags.length; i++) {
+    const newFrag = newFrags[i];
+    if (newFrag.initSegment?.relurl == lastNewFrag?.initSegment?.relurl) {
+      newFrag.initSegment = lastNewFrag.initSegment;
+    }
+  }
 }
 
 export function adjustSliding(


### PR DESCRIPTION
## Description

Download initial segment repeatedly when hint segment is canceled by server.

## To do

-   [ ] Bump it