### PR TITLE
Fix/doris 1100 freeze on disco

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.7",
+  "version": "0.14.17-doris.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.13",
+  "version": "0.14.17-doris.14",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -46,8 +46,11 @@ class AudioStreamController extends BaseStreamController {
     this.audioCodecSwap = false;
     this._state = State.STOPPED;
     this.initPTS = [];
+    /** A pending audio fragment that loaded but cannot be buffered yet as it's initPTS is unknown. */
     this.waitingFragment = null;
+    /** The current CC of the video track. */
     this.videoTrackCC = null;
+    /** The CC of the video track at the time `this.waitingFragment` was put on hold. */
     this.waitingVideoCC = null;
   }
 
@@ -344,6 +347,8 @@ class AudioStreamController extends BaseStreamController {
           if (bufferInfo.end !== 0 && waitingFragmentAtPosition < 0) {
             logger.log(`Waiting fragment cc (${waitingFragCC}) @ ${waitingFrag.frag.start} cancelled because another fragment at ${bufferInfo.end} is needed`);
             this.clearWaitingFragment();
+          } else if (this.waitingVideoCC != null) {
+            this.hls.trigger(Event.VIDEO_PTS_NEEDED, { cc: waitingFragCC });
           }
         }
       } else {

--- a/src/events.js
+++ b/src/events.js
@@ -112,7 +112,9 @@ const HlsEvents = {
   // fired upon stream controller state transitions - data: { previousState, nextState }
   STREAM_STATE_TRANSITION: 'hlsStreamStateTransition',
   // fired when the live back buffer is reached defined by the liveBackBufferLength config option - data : { bufferEnd: number }
-  LIVE_BACK_BUFFER_REACHED: 'hlsLiveBackBufferReached'
+  LIVE_BACK_BUFFER_REACHED: 'hlsLiveBackBufferReached',
+  // fired when audio stream controller is stuck and requires video PTS to be available for a continuity, this is a temporary fix until v1
+  VIDEO_PTS_NEEDED: 'hlsVideoPtsNeeded'
 };
 
 export default HlsEvents;


### PR DESCRIPTION
## Description

Introduce a new event `VIDEO_PTS_NEEDED` that allows the `audio-stream-controller` to notify the `stream-controller` when it's in a deadlock. The `stream-controller` will prioritize the download of the last fragment inside the required continuity to get the `audio-stream-controller` to resume downloading files.

This fixes issues where audio / video manifests are slightly offset, and a seek happens to the edge of a discontinuity.