### PR TITLE
fix: audio stream controller idling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.15",
+  "version": "0.14.17-doris.16",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.16",
+  "version": "0.14.17-doris.17",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -562,8 +562,8 @@ class AudioStreamController extends BaseStreamController {
     } else if (fragLoaded.type === 'audio') {
       // Make sure abandoned fragments are removed from the fragment tracker
       // otherwise they will not be loaded the next time they are requested.
-      logger.log(`Dropping audio fragment ${data.frag.sn} as it is no longer needed`);
-      this.fragmentTracker.removeFragment(data.frag);
+      logger.log(`Dropping audio fragment ${fragLoaded.sn} as it is no longer needed`);
+      this.fragmentTracker.removeFragment(fragLoaded);
     }
     this.fragLoadError = 0;
   }
@@ -711,6 +711,11 @@ class AudioStreamController extends BaseStreamController {
       this.stats.tparsed = performance.now();
       this.state = State.PARSED;
       this._checkAppendedParsed();
+    } else if (data.id === 'audio') {
+      // Make sure abandoned fragments are removed from the fragment tracker
+      // otherwise they will not be loaded the next time they are requested.
+      logger.log(`Dropping audio fragment ${fragNew.sn} as it is no longer needed`);
+      this.fragmentTracker.removeFragment(fragNew);
     }
   }
 

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -283,8 +283,9 @@ class AudioStreamController extends BaseStreamController {
               frag = trackDetails.initSegments[frag.initSegment].fragment;
             }
             this.fragCurrent = frag;
-            if (audioSwitch || this.fragmentTracker.getState(frag) !== FragmentState.OK) {
-              if (this.fragmentTracker.getState(frag) !== FragmentState.NOT_LOADED) {
+            const fragState = this.fragmentTracker.getState(frag);
+            if (audioSwitch || fragState !== FragmentState.OK) {
+              if (fragState !== FragmentState.NOT_LOADED) {
                 logger.log(`Re-loading audio fragment ${frag.sn}`);
               }
               logger.log(`Loading ${frag.sn}, cc: ${frag.cc} of [${trackDetails.startSN} ,${trackDetails.endSN}],track ${trackId}, ${

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -556,6 +556,11 @@ class AudioStreamController extends BaseStreamController {
           this.state = State.WAITING_INIT_PTS;
         }
       }
+    } else if (fragLoaded.type === 'audio') {
+      // Make sure abandoned fragments are removed from the fragment tracker
+      // otherwise they will not be loaded the next time they are requested.
+      logger.log(`Dropping audio fragment ${data.frag.sn} as it is no longer needed`);
+      this.fragmentTracker.removeFragment(data.frag);
     }
     this.fragLoadError = 0;
   }

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -283,7 +283,10 @@ class AudioStreamController extends BaseStreamController {
               frag = trackDetails.initSegments[frag.initSegment].fragment;
             }
             this.fragCurrent = frag;
-            if (audioSwitch || this.fragmentTracker.getState(frag) === FragmentState.NOT_LOADED) {
+            if (audioSwitch || this.fragmentTracker.getState(frag) !== FragmentState.OK) {
+              if (this.fragmentTracker.getState(frag) !== FragmentState.NOT_LOADED) {
+                logger.log(`Re-loading audio fragment ${frag.sn}`);
+              }
               logger.log(`Loading ${frag.sn}, cc: ${frag.cc} of [${trackDetails.startSN} ,${trackDetails.endSN}],track ${trackId}, ${
                 this.loadedmetadata ? 'currentTime' : 'nextLoadPosition'
               }: ${pos}, bufferEnd: ${bufferEnd.toFixed(3)}`);

--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -32,7 +32,8 @@ class AudioTrackController extends TaskLoop {
       Event.MANIFEST_PARSED,
       Event.AUDIO_TRACK_LOADED,
       Event.AUDIO_TRACK_SWITCHED,
-      Event.LEVEL_LOADED,
+      Event.LEVEL_LOADING,
+      Event.LEVEL_SWITCHING,
       Event.ERROR
     );
 
@@ -145,7 +146,7 @@ class AudioTrackController extends TaskLoop {
   }
 
   /**
-   * When a level gets loaded, if it has redundant audioGroupIds (in the same ordinality as it's redundant URLs)
+   * When a level starts loading, if it has redundant audioGroupIds (in the same ordinality as it's redundant URLs)
    * we are setting our audio-group ID internally to the one set, if it is different from the group ID currently set.
    *
    * If group-ID got update, we re-select the appropriate audio-track with this group-ID matching the currently
@@ -153,7 +154,20 @@ class AudioTrackController extends TaskLoop {
    *
    * @param {*} data
    */
-  onLevelLoaded (data) {
+   onLevelLoading (data) {
+    this._selectAudioGroup(data.level);
+  }
+
+  /**
+   * When a level switching starts, if it has redundant audioGroupIds (in the same ordinality as it's redundant URLs)
+   * we are setting our audio-group ID internally to the one set, if it is different from the group ID currently set.
+   *
+   * If group-ID got update, we re-select the appropriate audio-track with this group-ID matching the currently
+   * selected one (based on NAME property).
+   *
+   * @param {*} data
+   */
+  onLevelSwitching (data) {
     this._selectAudioGroup(data.level);
   }
 


### PR DESCRIPTION
## Description
- Remove non-buffered audio fragments from the `fragmentTracker` if they are abandoned during fragment loading or parsing. This is to ensure abandoned audio segments are not causing the audio stream controller to get stuck in `IDLE` state. Additionally the audio stream controller now re-downloads segments that are not marked as `buffered` but are in the `fragmentTracker` (mirroring the logic of the video stream controller).
- Fix issue where audio groups are not switched when loading a level for the second time when watching VOD streams. This was due to variant playlist only being loaded once, and audio track switching was tied to `LEVEL_LOADED` events. Moved this logic to happen on `LEVEL_SWITCHING` and `LEVEL_LOADING` events, mirroring the v1 logic.

## To do
- [x] Bump version