### PR TITLE
Fix/doris 1100 freeze on disco

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.14.17-doris.17",
+  "version": "0.14.17-doris.19",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -269,7 +269,7 @@ class AudioTrackController extends TaskLoop {
     }
 
     const audioGroupId = levelInfo.audioGroupIds[levelInfo.urlId];
-    if (this.audioGroupId !== audioGroupId) {
+    if (this.audioGroupId !== audioGroupId && this.tracks.length > 0) {
       this.audioGroupId = audioGroupId;
       this._selectInitialAudioTrack();
     }


### PR DESCRIPTION
With configuration "autoStartLoad=true", play failed for stream with audio group, because  audio tracks is empty.