### PR TITLE
Bugfix/freeze because video initial pts cannot be gotten for audio demuxer

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -220,11 +220,8 @@ class AudioStreamController
               );
               this.clearWaitingFragment();
             } else {
-              if (this.waitingVideoCC === -1 && this.videoTrackCC !== - 1) {
-                this.waitingVideoCC = this.videoTrackCC;
-              }
               if (this.waitingVideoCC !== -1 && frag.cc < this.waitingVideoCC) {
-                this.hls.trigger(Events.VIDEO_PTS_NEEDED, { cc:  frag.cc });
+                this.hls.trigger(Events.VIDEO_PTS_NEEDED, { cc: frag.cc });
               }
             }
           }

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -160,7 +160,7 @@ class AudioStreamController
           if (this.waitForCdnTuneIn(details)) {
             break;
           }
-          this.state = State.WAITING_INIT_PTS;
+          this.state = State.IDLE;
         }
         break;
       }
@@ -182,6 +182,7 @@ class AudioStreamController
           if (this.initPTS[frag.cc] !== undefined) {
             this.waitingData = null;
             this.waitingVideoCC = -1;
+            this.videoTrackCC = -1;
             this.state = State.FRAG_LOADING;
             const payload = cache.flush();
             const data: FragLoadedData = {
@@ -218,6 +219,13 @@ class AudioStreamController
                 `Waiting fragment cc (${frag.cc}) @ ${frag.start} cancelled because another fragment at ${bufferInfo.end} is needed`
               );
               this.clearWaitingFragment();
+            } else {
+              if (this.waitingVideoCC === -1 && this.videoTrackCC !== - 1) {
+                this.waitingVideoCC = this.videoTrackCC;
+              }
+              if (this.waitingVideoCC !== -1 && frag.cc < this.waitingVideoCC) {
+                this.hls.trigger(Events.VIDEO_PTS_NEEDED, { cc:  frag.cc });
+              }
             }
           }
         } else {
@@ -794,11 +802,6 @@ class AudioStreamController
     ) {
       if (frag.sn === 'initSegment') {
         this._loadInitSegment(frag);
-      } else if (trackDetails.live && !Number.isFinite(this.initPTS[frag.cc])) {
-        this.log(
-          `Waiting for video PTS in continuity counter ${frag.cc} of live stream before loading audio fragment ${frag.sn} of level ${this.trackId}`
-        );
-        this.state = State.WAITING_INIT_PTS;
       } else {
         this.startFragRequested = true;
         super.loadFragment(frag, trackDetails, targetBufferTime);

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -91,6 +91,7 @@ export default class BaseStreamController
   protected startFragRequested: boolean = false;
   protected decrypter: Decrypter;
   protected initPTS: Array<number> = [];
+  protected reAlignCC: number | null = null;
   protected onvseeking: EventListener | null = null;
   protected onvended: EventListener | null = null;
 
@@ -977,19 +978,31 @@ export default class BaseStreamController
     }
 
     let frag;
-    if (bufferEnd < end) {
-      const lookupTolerance = bufferEnd > end - tolerance ? 0 : tolerance;
-      // Remove the tolerance if it would put the bufferEnd past the actual end of stream
-      // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
-      frag = findFragmentByPTS(
-        fragPrevious,
-        fragments,
-        bufferEnd,
-        lookupTolerance
-      );
-    } else {
-      // reach end of playlist
-      frag = fragments[fragments.length - 1];
+    if (this.reAlignCC != null && this.fragPrevious?.cc !== this.reAlignCC) {
+      const fragmentsWithMatchingCC = fragments.filter((fragment) => fragment.cc === this.reAlignCC);
+
+      // Use the last fragment with matching CC as this issue generally occurs at the end of discontinuities
+      // with slightly offset audio / video manifests.
+      frag = fragmentsWithMatchingCC[fragmentsWithMatchingCC.length - 1];
+      this.reAlignCC = null;
+      logger.info(`Loading video segment ${frag.sn} (cc: ${frag.cc}) to get initPTS for audio-stream-controller.`);
+    }
+
+    if (!frag) {
+      if (bufferEnd < end) {
+        const lookupTolerance = bufferEnd > end - tolerance ? 0 : tolerance;
+        // Remove the tolerance if it would put the bufferEnd past the actual end of stream
+        // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
+        frag = findFragmentByPTS(
+          fragPrevious,
+          fragments,
+          bufferEnd,
+          lookupTolerance
+        );
+      } else {
+        // reach end of playlist
+        frag = fragments[fragments.length - 1];
+      }
     }
 
     if (frag) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -34,6 +34,7 @@ import type {
   LevelsUpdatedData,
   ManifestParsedData,
   MediaAttachedData,
+  VideoPTSNeededCC,
 } from '../types/events';
 
 const TICK_INTERVAL = 100; // how often to tick in ms
@@ -82,6 +83,7 @@ export default class StreamController
     hls.on(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
     hls.on(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.on(Events.FRAG_BUFFERED, this.onFragBuffered, this);
+    hls.on(Events.VIDEO_PTS_NEEDED, this.onVideoPtsNeeded, this);
   }
 
   protected _unregisterListeners() {
@@ -103,6 +105,7 @@ export default class StreamController
     hls.off(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
     hls.off(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.off(Events.FRAG_BUFFERED, this.onFragBuffered, this);
+    hls.on(Events.VIDEO_PTS_NEEDED, this.onVideoPtsNeeded, this);
   }
 
   protected onHandlerDestroying() {
@@ -1352,5 +1355,9 @@ export default class StreamController
 
   get forceStartLoad() {
     return this._forceStartLoad;
+  }
+
+  onVideoPtsNeeded (event: Events.VIDEO_PTS_NEEDED, data: VideoPTSNeededCC) {
+    this.reAlignCC = data.cc;
   }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -47,6 +47,7 @@ import {
   LiveBackBufferData,
   TrackLoadingData,
   BufferFlushedData,
+  VideoPTSNeededCC,
 } from './types/events';
 
 /**
@@ -166,6 +167,8 @@ export enum Events {
   LIVE_BACK_BUFFER_REACHED = 'hlsLiveBackBufferReached',
   // fired when the back buffer is reached as defined by the backBufferLength config option - data : { bufferEnd: number }
   BACK_BUFFER_REACHED = 'hlsBackBufferReached',
+  // fired when audio stream controller is stuck and requires video PTS to be available for a continuity, this is a temporary fix until v1
+  VIDEO_PTS_NEEDED = 'hlsVideoPtsNeeded',
 }
 
 export interface HlsListeners {
@@ -361,6 +364,10 @@ export interface HlsListeners {
   [Events.BACK_BUFFER_REACHED]: (
     event: Events.BACK_BUFFER_REACHED,
     data: BackBufferData
+  ) => void;
+  [Events.VIDEO_PTS_NEEDED]: (
+    event: Events.VIDEO_PTS_NEEDED,
+    data: VideoPTSNeededCC
   ) => void;
 }
 export interface HlsEventEmitter {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -72,6 +72,10 @@ export interface BufferFlushedData {
   type: SourceBufferName;
 }
 
+export interface VideoPTSNeededCC {
+  cc: number;
+}
+
 export interface ManifestLoadingData {
   url: string;
 }


### PR DESCRIPTION
### This PR will...
Introduce a new event VIDEO_PTS_NEEDED that allows the audio-stream-controller to notify the stream-controller when it's in a deadlock. The stream-controller will prioritize the download of the last fragment inside the required continuity to get the audio-stream-controller to resume downloading files.

### Why is this Pull Request needed?
This fixes issues where audio / video manifests are slightly offset, and a seek happens to the edge of a discontinuity.