### PR TITLE
Fix: media buffer gap when play ssai streams

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -46,6 +46,7 @@ export default class MP4Remuxer implements Remuxer {
   private nextAudioPts: number | null = null;
   private isAudioContiguous: boolean = false;
   private isVideoContiguous: boolean = false;
+  private checkIFrameOnDiscontinue: boolean = false;
 
   constructor(
     observer: HlsEventEmitter,
@@ -77,6 +78,7 @@ export default class MP4Remuxer implements Remuxer {
   resetTimeStamp(defaultTimeStamp) {
     logger.log('[mp4-remuxer]: initPTS & initDTS reset');
     this._initPTS = this._initDTS = defaultTimeStamp;
+    this.checkIFrameOnDiscontinue = true;
   }
 
   resetNextTimestamp() {
@@ -155,7 +157,11 @@ export default class MP4Remuxer implements Remuxer {
 
       if (enoughVideoSamples) {
         firstKeyFrameIndex = findKeyframeIndex(videoTrack.samples);
-        if (!isVideoContiguous && this.config.forceKeyFrameOnDiscontinuity) {
+        if (
+          this.config.forceKeyFrameOnDiscontinuity &&
+          (!isVideoContiguous ||
+            (this.checkIFrameOnDiscontinue && firstKeyFrameIndex > 0))
+        ) {
           independent = true;
           if (firstKeyFrameIndex > 0) {
             logger.warn(
@@ -163,6 +169,9 @@ export default class MP4Remuxer implements Remuxer {
             );
             const startPTS = this.getVideoStartPts(videoTrack.samples);
             videoTrack.samples = videoTrack.samples.slice(firstKeyFrameIndex);
+            if (this.checkIFrameOnDiscontinue) {
+              firstKeyFrameIndex = 0;
+            }
             videoTrack.dropped += firstKeyFrameIndex;
             videoTimeOffset +=
               (videoTrack.samples[0].pts - startPTS) /
@@ -631,6 +640,7 @@ export default class MP4Remuxer implements Remuxer {
     // next AVC sample DTS should be equal to last sample DTS + last sample duration (in PES timescale)
     this.nextAvcDts = nextAvcDts = lastDTS + mp4SampleDuration;
     this.isVideoContiguous = true;
+    this.checkIFrameOnDiscontinue = false;
     const moof = MP4.moof(
       track.sequenceNumber++,
       firstDTS,


### PR DESCRIPTION
### This PR will...
- Playback freeze for SSAI streams because the segment is not started with I frame after "discontinuity.

### Resolves issues:
https://dicetech.atlassian.net/browse/DORIS-1117
