### PR TITLE
Feat: Enhance latency controller

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1215,6 +1215,8 @@ export type LatencyControllerConfig = {
     liveSyncDuration?: number;
     liveMaxLatencyDuration?: number;
     maxLiveSyncPlaybackRate: number;
+    recoverFromStallPeriod: number;
+    recoverFromStallMinBuffer: number;
 };
 
 // Warning: (ae-missing-release-tag) "Level" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2156,18 +2158,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:163:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:172:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:173:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:175:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:176:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:177:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:179:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:182:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:184:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:185:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:186:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:187:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:165:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:174:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:175:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:177:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:178:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:179:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:181:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:184:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:186:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:187:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:188:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:189:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1216,7 +1216,8 @@ export type LatencyControllerConfig = {
     liveMaxLatencyDuration?: number;
     maxLiveSyncPlaybackRate: number;
     recoverFromStallPeriod: number;
-    recoverFromStallMinBuffer: number;
+    minSmoothPlaybackBuffer: number;
+    enableCatchupLoLP: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "Level" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2158,18 +2159,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:165:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:174:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:175:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:177:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:178:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:179:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:181:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:184:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:186:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:187:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:188:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:189:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:166:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:175:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:176:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:178:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:179:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:180:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:182:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:185:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:187:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:188:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:189:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:190:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.1.2-doris.4",
+  "version": "1.1.5-doris.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13154,7 +13154,7 @@
         },
         "@oclif/dev-cli": {
           "version": "1.26.0",
-          "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.26.0.tgz",
+          "resolved": false,
           "integrity": "sha512-272udZP+bG4qahoAcpWcMTJKiA+V42kRMqQM7n4tgW35brYb2UP5kK+p08PpF8sgSfRTV8MoJVJG9ax5kY82PA==",
           "requires": {
             "@oclif/command": "^1.8.0",
@@ -13587,7 +13587,7 @@
         },
         "@oclif/test": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/@oclif/test/-/test-1.2.8.tgz",
+          "resolved": false,
           "integrity": "sha512-HCh0qPge1JCqTEw4s2ScnicEZd4Ro4/0VvdjpsfCiX6fuDV53fRZ2uqLTgxKGHrVoqOZnVrRZHyhFyEsFGs+zQ==",
           "requires": {
             "fancy-test": "^1.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.1.2-doris.4",
+  "version": "1.1.5-doris.1",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -230,7 +230,7 @@ export const hlsDefaultConfig: HlsConfig = {
   maxLiveSyncPlaybackRate: 1, // used by latency-controller
   recoverFromStallPeriod: 60000, // used by latency-controller
   minSmoothPlaybackBuffer: 1, // used by latency-controller
-  enableCatchupLoLP: true, // used by latency-controller
+  enableCatchupLoLP: false, // used by latency-controller
   liveDurationInfinity: false, // used by buffer-controller
   liveBackBufferLength: null, // used by buffer-controller
   maxMaxBufferLength: 600, // used by stream-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -228,7 +228,7 @@ export const hlsDefaultConfig: HlsConfig = {
   liveSyncDuration: undefined, // used by latency-controller
   liveMaxLatencyDuration: undefined, // used by latency-controller
   maxLiveSyncPlaybackRate: 1, // used by latency-controller
-  recoverFromStallPeriod: 60, // used by latency-controller
+  recoverFromStallPeriod: 60000, // used by latency-controller
   minSmoothPlaybackBuffer: 1, // used by latency-controller
   enableCatchupLoLP: true, // used by latency-controller
   liveDurationInfinity: false, // used by buffer-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -137,6 +137,8 @@ export type LatencyControllerConfig = {
   liveSyncDuration?: number;
   liveMaxLatencyDuration?: number;
   maxLiveSyncPlaybackRate: number;
+  recoverFromStallPeriod: number;
+  recoverFromStallMinBuffer: number;
 };
 
 export type TimelineControllerConfig = {
@@ -225,6 +227,8 @@ export const hlsDefaultConfig: HlsConfig = {
   liveSyncDuration: undefined, // used by latency-controller
   liveMaxLatencyDuration: undefined, // used by latency-controller
   maxLiveSyncPlaybackRate: 1, // used by latency-controller
+  recoverFromStallPeriod: 60, // used by latency-controller
+  recoverFromStallMinBuffer: 2, // used by latency-controller
   liveDurationInfinity: false, // used by buffer-controller
   liveBackBufferLength: null, // used by buffer-controller
   maxMaxBufferLength: 600, // used by stream-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,7 +138,8 @@ export type LatencyControllerConfig = {
   liveMaxLatencyDuration?: number;
   maxLiveSyncPlaybackRate: number;
   recoverFromStallPeriod: number;
-  recoverFromStallMinBuffer: number;
+  minSmoothPlaybackBuffer: number;
+  enableCatchupLoLP: boolean;
 };
 
 export type TimelineControllerConfig = {
@@ -228,7 +229,8 @@ export const hlsDefaultConfig: HlsConfig = {
   liveMaxLatencyDuration: undefined, // used by latency-controller
   maxLiveSyncPlaybackRate: 1, // used by latency-controller
   recoverFromStallPeriod: 60, // used by latency-controller
-  recoverFromStallMinBuffer: 2, // used by latency-controller
+  minSmoothPlaybackBuffer: 1, // used by latency-controller
+  enableCatchupLoLP: true, // used by latency-controller
   liveDurationInfinity: false, // used by buffer-controller
   liveBackBufferLength: null, // used by buffer-controller
   maxMaxBufferLength: 600, // used by stream-controller

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -196,7 +196,7 @@ export default class LatencyController implements ComponentAPI {
     { details }: LevelUpdatedData
   ) {
     this.levelDetails = details;
-    if (details.live && details.advanced) {
+    if (details.advanced) {
       this.timeupdate();
     }
     if (!details.live && this.media) {
@@ -261,7 +261,7 @@ export default class LatencyController implements ComponentAPI {
             20
         ) / 20;
       media.playbackRate = Math.min(max, Math.max(1, rate));
-    } else if (!inLiveRange && this.liveSyncPosition) {
+    } else if (levelDetails.live && !inLiveRange && this.liveSyncPosition) {
       // alway seek to live sync position when current position is larger enough
       media.currentTime = this.liveSyncPosition;
     } else if (media.playbackRate !== 1 && media.playbackRate !== 0) {

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -69,10 +69,8 @@ export default class LatencyController implements ComponentAPI {
     const { recoverFromStallPeriod, minSmoothPlaybackBuffer } = this.config;
     if (
       lowLatencyMode &&
-      recoverFromStallPeriod &&
-      minSmoothPlaybackBuffer &&
       this.stallCount > 0 &&
-      Date.now() - this._lastStallTime > recoverFromStallPeriod * 1000 && // no buffering in certain period
+      Date.now() - this._lastStallTime > recoverFromStallPeriod && // no buffering in certain period
       this.forwardBufferLength > minSmoothPlaybackBuffer
     ) {
       // have enough data

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -66,14 +66,14 @@ export default class LatencyController implements ComponentAPI {
     const liveSyncOnStallIncrease = 1.0;
 
     // try to recover
-    const { recoverFromStallPeriod, recoverFromStallMinBuffer } = this.config;
+    const { recoverFromStallPeriod, minSmoothPlaybackBuffer } = this.config;
     if (
       lowLatencyMode &&
       recoverFromStallPeriod &&
-      recoverFromStallMinBuffer &&
+      minSmoothPlaybackBuffer &&
       this.stallCount > 0 &&
       Date.now() - this._lastStallTime > recoverFromStallPeriod * 1000 && // no buffering in certain period
-      this.forwardBufferLength > recoverFromStallMinBuffer
+      this.forwardBufferLength > minSmoothPlaybackBuffer
     ) {
       // have enough data
       this._lastStallTime = Date.now();
@@ -232,7 +232,12 @@ export default class LatencyController implements ComponentAPI {
     this._latency = latency;
 
     // Adapt playbackRate to meet target latency in low-latency mode
-    const { lowLatencyMode, maxLiveSyncPlaybackRate } = this.config;
+    const {
+      enableCatchupLoLP,
+      lowLatencyMode,
+      maxLiveSyncPlaybackRate,
+      minSmoothPlaybackBuffer,
+    } = this.config;
     if (!lowLatencyMode || maxLiveSyncPlaybackRate === 1) {
       return;
     }
@@ -240,34 +245,36 @@ export default class LatencyController implements ComponentAPI {
     if (targetLatency === null) {
       return;
     }
+    // Only adjust playbackRate on browsers for now
+    if (this.canDeviceChangePlaybackRate()) {
+      const newRate = enableCatchupLoLP
+        ? this.calculateNewPlaybackRateLolP(media, latency, targetLatency)
+        : this.calculateNewPlaybackRateDefault(
+            media,
+            latency,
+            targetLatency,
+            levelDetails
+          );
+      if (newRate) {
+        media.playbackRate = newRate;
+      }
+    }
+
+    // seek to live edge
     const distanceFromTarget = latency - targetLatency;
-    // Only adjust playbackRate when within one target duration of targetLatency
-    // and more than one second from under-buffering.
-    // Playback further than one target duration from target can be considered DVR playback.
     const liveMinLatencyDuration = Math.min(
       this.maxLatency,
       targetLatency + levelDetails.targetduration
     );
-    const inLiveRange = distanceFromTarget < liveMinLatencyDuration;
     if (
       levelDetails.live &&
-      inLiveRange &&
-      distanceFromTarget > 0.05 &&
-      this.forwardBufferLength > 1 &&
-      this.canDeviceChangePlaybackRate() // Only adjust playbackRate on browsers for now
+      this.stallCount === 0 &&
+      this.forwardBufferLength > minSmoothPlaybackBuffer &&
+      distanceFromTarget > liveMinLatencyDuration &&
+      this.liveSyncPosition
     ) {
-      const max = Math.min(2, Math.max(1.0, maxLiveSyncPlaybackRate));
-      const rate =
-        Math.round(
-          (2 / (1 + Math.exp(-0.75 * distanceFromTarget - this.edgeStalled))) *
-            20
-        ) / 20;
-      media.playbackRate = Math.min(max, Math.max(1, rate));
-    } else if (levelDetails.live && !inLiveRange && this.liveSyncPosition) {
       // alway seek to live sync position when current position is larger enough
       media.currentTime = this.liveSyncPosition;
-    } else if (media.playbackRate !== 1 && media.playbackRate !== 0) {
-      media.playbackRate = 1;
     }
   }
 
@@ -288,7 +295,8 @@ export default class LatencyController implements ComponentAPI {
   }
 
   private canDeviceChangePlaybackRate(): boolean {
-    const ua = navigator?.userAgent.toLowerCase() || '';
+    const ua =
+      typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : '';
     // According to https://bugs.webkit.org/show_bug.cgi?id=208142
     // changing playbackRate in Safari can cause video playback disruption.
     const isSafari = /safari/.test(ua) && !/chrome/.test(ua);
@@ -300,5 +308,91 @@ export default class LatencyController implements ComponentAPI {
       isSafari
     );
     return !isDeviceNotSupported;
+  }
+
+  private calculateNewPlaybackRateDefault(
+    media: HTMLMediaElement,
+    latency: number,
+    targetLatency: number,
+    levelDetails: LevelDetails
+  ) {
+    const distanceFromTarget = latency - targetLatency;
+    // Only adjust playbackRate when within one target duration of targetLatency
+    // and more than one second from under-buffering.
+    // Playback further than one target duration from target can be considered DVR playback.
+    const liveMinLatencyDuration = Math.min(
+      this.maxLatency,
+      targetLatency + levelDetails.targetduration
+    );
+    let newRate;
+    const inLiveRange = distanceFromTarget < liveMinLatencyDuration;
+    if (
+      levelDetails.live &&
+      inLiveRange &&
+      distanceFromTarget > 0.05 &&
+      this.forwardBufferLength > 1 &&
+      this.canDeviceChangePlaybackRate() // Only adjust playbackRate on browsers for now
+    ) {
+      const { maxLiveSyncPlaybackRate } = this.config;
+      const max = Math.min(2, Math.max(1.0, maxLiveSyncPlaybackRate));
+      const rate =
+        Math.round(
+          (2 / (1 + Math.exp(-0.75 * distanceFromTarget - this.edgeStalled))) *
+            20
+        ) / 20;
+      newRate = Math.min(max, Math.max(1, rate));
+    } else if (media.playbackRate !== 1 && media.playbackRate !== 0) {
+      newRate = 1;
+    }
+    return newRate;
+  }
+
+  private calculateNewPlaybackRateLolP(
+    media: HTMLMediaElement,
+    latency: number,
+    targetLatency: number
+  ) {
+    const { minSmoothPlaybackBuffer, maxLiveSyncPlaybackRate } = this.config;
+
+    const cpr = maxLiveSyncPlaybackRate - 1;
+    let newRate;
+
+    const bufferLevel = this.forwardBufferLength;
+    // Hybrid: Buffer-based
+    if (bufferLevel < minSmoothPlaybackBuffer) {
+      // Buffer in danger, slow down
+      const deltaBuffer = bufferLevel - minSmoothPlaybackBuffer; // -ve value
+      const d = deltaBuffer * 5;
+
+      // Playback rate must be between (1 - cpr) - (1 + cpr)
+      // ex: if cpr is 0.5, it can have values between 0.5 - 1.5
+      const s = (cpr * 2) / (1 + Math.pow(Math.E, -d));
+      newRate = 1 - cpr + s;
+    } else {
+      // Hybrid: Latency-based
+      // Buffer is safe, vary playback rate based on latency
+
+      // Check if latency is within range of target latency
+      const minDifference = 0.1;
+      if (Math.abs(latency - targetLatency) <= minDifference * targetLatency) {
+        newRate = 1;
+      } else {
+        const deltaLatency = latency - targetLatency;
+        const d = deltaLatency * 5;
+
+        // Playback rate must be between (1 - cpr) - (1 + cpr)
+        // ex: if cpr is 0.5, it can have values between 0.5 - 1.5
+        const s = (cpr * 2) / (1 + Math.pow(Math.E, -d));
+        newRate = 1 - cpr + s;
+      }
+    }
+
+    // don't change playbackrate for small variations (don't overload element with playbackrate changes)
+    const minPlaybackRateChange = 0.02;
+    if (Math.abs(media.playbackRate - newRate) <= minPlaybackRateChange) {
+      newRate = null;
+    }
+
+    return newRate;
   }
 }

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -290,12 +290,12 @@ export default class LatencyController implements ComponentAPI {
     // changing playbackRate in Safari can cause video playback disruption.
     const isSafari = /safari/.test(ua) && !/chrome/.test(ua);
     // Changing playbackRate in some devices also cause video playback disruption.
-    const isDeviceNotSupported = ['xbox', 'webos', 'tizen'].reduce(
+    const isDeviceNotSupported = ['xbox', 'web0s', 'tizen'].reduce(
       (result: boolean, deviceUA: string) => {
         return result || ua.indexOf(deviceUA) !== -1;
       },
-      false
+      isSafari
     );
-    return !(isSafari || isDeviceNotSupported);
+    return !isDeviceNotSupported;
   }
 }

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -140,9 +140,11 @@ export default class LatencyController implements ComponentAPI {
       return 0;
     }
     const bufferedRanges = media.buffered.length;
-    return bufferedRanges
-      ? media.buffered.end(bufferedRanges - 1)
-      : levelDetails.edge - this.currentTime;
+    return (
+      (bufferedRanges
+        ? media.buffered.end(bufferedRanges - 1)
+        : levelDetails.edge) - this.currentTime
+    );
   }
 
   public destroy(): void {

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -68,6 +68,7 @@ export default class LatencyController implements ComponentAPI {
     // try to recover
     const { recoverFromStallPeriod, recoverFromStallMinBuffer } = this.config;
     if (
+      lowLatencyMode &&
       recoverFromStallPeriod &&
       recoverFromStallMinBuffer &&
       this.stallCount > 0 &&

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -195,7 +195,7 @@ export default class LatencyController implements ComponentAPI {
     { details }: LevelUpdatedData
   ) {
     this.levelDetails = details;
-    if (details.advanced) {
+    if (details.live && details.advanced) {
       this.timeupdate();
     }
     if (!details.live && this.media) {


### PR DESCRIPTION
### This PR will...
Enhance latency controller for better low latency experience:
- Speed up: Adjust playback speed to catchup, for desktop browsers (Chrome/Firefox/Opera/...) only, will no execute on browsers/devices have problem to catchup with playback speed changing. 
- Auto seek to edge: Once playback position is far away from live edge like target latency + target duration, player will seek to live edge automatically.
- Seek/Pause will not work in low latency mode in case Auto seek to edge on.
- Use LoL+ catchup algorithm for smooth playback. (`enableCatchupLoLP` false by default)
### Resolves issues:
[DORIS-972](https://dicetech.atlassian.net/browse/DORIS-972)