### PR TITLE
fix: contiguous detection error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -161,7 +161,7 @@ export default class TransmuxerInterface {
     const discontinuity = !(lastFrag && frag.cc === lastFrag.cc);
     const trackSwitch = !(lastFrag && chunkMeta.level === lastFrag.level);
     const snDiff = lastFrag ? chunkMeta.sn - (lastFrag.sn as number) : -1;
-    const partDiff = this.part ? chunkMeta.part - this.part.index : 1;
+    const partDiff = this.part ? chunkMeta.part - this.part.index : -1;
     const contiguous =
       !trackSwitch && (snDiff === 1 || (snDiff === 0 && partDiff === 1));
     const now = self.performance.now();


### PR DESCRIPTION
### This PR will...
Fixes bug of playback stuck after BUFFER_FULL_ERROR when maxBufferSize set to a very big value.

### Why is this Pull Request needed?
Per design, `contiguous` will be true when:
- track not switched
- `sn` in sequence
  - or same `sn` but `part sn` in sequence (low latency mode)

But partDiff is always 1 in current implementation, so `contiguous` will be true even sn is same for non-low-latency streams, which is not correct.