### PR TITLE
Bugfix/add support for emsg id3 metadata in fmp4 segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ HLS.js is written in [ECMAScript6] (`*.js`) and [TypeScript] (`*.ts`) (strongly 
   - Packetized metadata (ID3v2.3.0) Elementary Stream
 - AAC container (audio only streams)
 - MPEG Audio container (MPEG-1/2 Audio Layer III audio only streams)
-- Timed Metadata for HTTP Live Streaming (in ID3 format, carried in MPEG-2 TS)
+- Timed Metadata for HTTP Live Streaming (in ID3 format, carried in MPEG-2 TS and FMP4 Emsg)
 - AES-128 decryption
 - SAMPLE-AES decryption (only supported if using MPEG-2 TS container)
 - Encrypted media extensions (EME) support for DRM (digital rights management)
@@ -113,8 +113,6 @@ The following tags are added to their respective fragment's attribute list but a
 
 For a complete list of issues, see ["Top priorities" in the Release Planning and Backlog project tab](https://github.com/video-dev/hls.js/projects/6). Codec support is dependent on the runtime environment (for example, not all browsers on the same OS support HEVC).
 
-- CMAF CC support [#2623](https://github.com/video-dev/hls.js/issues/2623)
-- `Emsg` Inband Timed Metadata for FMP4 (ID3 within Emsgv1) in "metadata" TextTracks [#2360](https://github.com/video-dev/hls.js/issues/2360)
 - `#EXT-X-DATERANGE` in "metadata" TextTracks [#2218](https://github.com/video-dev/hls.js/issues/2218)
 - `#EXT-X-GAP` filling [#2940](https://github.com/video-dev/hls.js/issues/2940)
 - `#EXT-X-I-FRAME-STREAM-INF` I-frame Media Playlist files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -15,16 +15,22 @@ import {
   segmentValidRange,
   appendUint8Array,
   parseEmsg,
+  parseEarlieastPresentationTime,
 } from '../utils/mp4-tools';
 import { dummyTrack } from './dummy-demuxed-track';
 import type { HlsEventEmitter } from '../events';
 import type { HlsConfig } from '../config';
 
-const emsgSchemePattern = /\/emsg[-/]ID3/i;
+// Support scheme
+//   'https://aomedia.org/emsg/ID3',
+//   'https://developer.apple.com/streaming/emsg-id3',
+//    urn:scte:scte35:2013:xml
+const emsgSchemePattern = /\/emsg[-/]ID3|urn:scte:scte35:2013:xml/i;
 
 class MP4Demuxer implements Demuxer {
   static readonly minProbeByteLength = 1024;
   private remainderData: Uint8Array | null = null;
+  private timeOffset: number = 0;
   private config: HlsConfig;
 
   constructor(observer: HlsEventEmitter, config: HlsConfig) {
@@ -33,7 +39,9 @@ class MP4Demuxer implements Demuxer {
 
   resetTimeStamp() {}
 
-  resetInitSegment() {}
+  resetInitSegment() {
+    this.timeOffset = 0;
+  }
 
   resetContiguity(): void {}
 
@@ -47,6 +55,7 @@ class MP4Demuxer implements Demuxer {
   }
 
   demux(data: Uint8Array, timeOffset: number): DemuxerResult {
+    this.timeOffset = timeOffset;
     // Load all data into the avc track. The CMAF remuxer will look for the data in the samples object; the rest of the fields do not matter
     let avcSamples = data;
     const avcTrack = dummyTrack() as PassthroughVideoTrack;
@@ -64,26 +73,7 @@ class MP4Demuxer implements Demuxer {
       avcTrack.samples = avcSamples;
     }
 
-    const id3Track = dummyTrack() as DemuxedMetadataTrack;
-    const emsgs = findBox(avcTrack.samples, ['emsg']);
-    if (emsgs) {
-      id3Track.inputTimeScale = 1;
-      emsgs.forEach(({ data, start, end }) => {
-        const emsgInfo = parseEmsg(data.subarray(start, end));
-        if (emsgSchemePattern.test(emsgInfo.schemeIdUri)) {
-          const pts = Number.isFinite(emsgInfo.presentationTime)
-            ? emsgInfo.presentationTime! / emsgInfo.timeScale
-            : timeOffset + emsgInfo.presentationTimeDelta! / emsgInfo.timeScale;
-          const payload = emsgInfo.payload;
-          id3Track.samples.push({
-            data: payload,
-            len: payload.byteLength,
-            dts: pts,
-            pts: pts,
-          });
-        }
-      });
-    }
+    const id3Track = this.extractID3Track(avcTrack, timeOffset);
 
     return {
       audioTrack: dummyTrack() as DemuxedAudioTrack,
@@ -98,12 +88,49 @@ class MP4Demuxer implements Demuxer {
     avcTrack.samples = this.remainderData || new Uint8Array();
     this.remainderData = null;
 
+    const id3Track = this.extractID3Track(avcTrack, this.timeOffset);
     return {
       audioTrack: dummyTrack() as DemuxedAudioTrack,
       avcTrack,
-      id3Track: dummyTrack() as DemuxedMetadataTrack,
+      id3Track,
       textTrack: dummyTrack() as DemuxedUserdataTrack,
     };
+  }
+
+  private extractID3Track(
+    videoTrack: PassthroughVideoTrack,
+    timeOffset: number
+  ): DemuxedMetadataTrack {
+    const id3Track = dummyTrack() as DemuxedMetadataTrack;
+    id3Track.type = 'id3';
+    id3Track.inputTimeScale = 1;
+    if (videoTrack.samples.length) {
+      let earliestPresentationTime = 0;
+      const sidxInfo = parseEarlieastPresentationTime(videoTrack.samples);
+      if (sidxInfo) {
+        earliestPresentationTime = sidxInfo.earliestPresentationTime / sidxInfo.timescale;
+      }
+      const emsgs = findBox(videoTrack.samples, ['emsg']);
+      if (emsgs) {
+        emsgs.forEach(({data, start, end}) => {
+          const emsgInfo = parseEmsg(data.subarray(start, end));
+          if (emsgSchemePattern.test(emsgInfo.schemeIdUri)) {
+            const pts = !Number.isFinite(emsgInfo.presentationTimeDelta)
+              ? emsgInfo.presentationTime! / emsgInfo.timeScale
+              : timeOffset + earliestPresentationTime +
+                emsgInfo.presentationTimeDelta! / emsgInfo.timeScale;
+            const payload = emsgInfo.payload;
+            id3Track.samples.push({
+              data: payload,
+              len: payload.byteLength,
+              dts: pts,
+              pts: pts,
+            });
+          }
+        });
+      }
+    }
+    return id3Track;
   }
 
   demuxSampleAes(

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -253,11 +253,20 @@ export default class MP4Remuxer implements Remuxer {
     // Allow ID3 and text to remux, even if more audio/video samples are required
     if (this.ISGenerated) {
       if (id3Track.samples.length) {
-        id3 = this.remuxID3(id3Track, timeOffset);
+        id3 = flushTextTrackMetadataCueSamples(
+          id3Track,
+          timeOffset,
+          this._initPTS,
+          this._initDTS
+        );
       }
 
       if (textTrack.samples.length) {
-        text = this.remuxText(textTrack, timeOffset);
+        text = flushTextTrackUserdataCueSamples(
+          textTrack,
+          timeOffset,
+          this._initPTS
+        );
       }
     }
 
@@ -1059,6 +1068,62 @@ function findKeyframeIndex(samples: Array<AvcSample>): number {
     }
   }
   return -1;
+}
+
+export function flushTextTrackMetadataCueSamples(
+  track: DemuxedMetadataTrack,
+  timeOffset: number,
+  initPTS: number,
+  initDTS: number
+): RemuxedMetadata | undefined {
+  const length = track.samples.length;
+  if (!length) {
+    return;
+  }
+  const inputTimeScale = track.inputTimeScale;
+  for (let index = 0; index < length; index++) {
+    const sample = track.samples[index];
+    // setting id3 pts, dts to relative time
+    // using this._initPTS and this._initDTS to calculate relative time
+    sample.pts =
+      normalizePts(sample.pts - initPTS, timeOffset * inputTimeScale) /
+      inputTimeScale;
+    sample.dts =
+      normalizePts(sample.dts - initDTS, timeOffset * inputTimeScale) /
+      inputTimeScale;
+  }
+  const samples = track.samples;
+  track.samples = [];
+  return {
+    samples,
+  };
+}
+
+export function flushTextTrackUserdataCueSamples(
+  track: DemuxedUserdataTrack,
+  timeOffset: number,
+  initPTS: number
+): RemuxedUserdata | undefined {
+  const length = track.samples.length;
+  if (!length) {
+    return;
+  }
+
+  const inputTimeScale = track.inputTimeScale;
+  for (let index = 0; index < length; index++) {
+    const sample = track.samples[index];
+    // setting text pts, dts to relative time
+    // using this._initPTS and this._initDTS to calculate relative time
+    sample.pts =
+      normalizePts(sample.pts - initPTS, timeOffset * inputTimeScale) /
+      inputTimeScale;
+  }
+  track.samples.sort((a, b) => a.pts - b.pts);
+  const samples = track.samples;
+  track.samples = [];
+  return {
+    samples,
+  };
 }
 
 class Mp4Sample {

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -6,7 +6,6 @@ import {
   offsetStartDTS,
   parseInitSegment,
   parseVideoSegmentTextTrackSamples,
-  parseId3TrackSamples,
 } from '../utils/mp4-tools';
 import { ElementaryStreamTypes } from '../loader/fragment';
 import { logger } from '../utils/logger';

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -657,6 +657,102 @@ export function appendUint8Array(
   return temp;
 }
 
+export interface IEmsgParsingData {
+  schemeIdUri: string;
+  value: string;
+  timeScale: number;
+  presentationTimeDelta?: number;
+  presentationTime?: number;
+  eventDuration: number;
+  id: number;
+  payload: Uint8Array;
+}
+
+export function parseEmsg(data: Uint8Array): IEmsgParsingData {
+  const version = data[0];
+  let schemeIdUri: string = '';
+  let value: string = '';
+  let timeScale: number = 0;
+  let presentationTimeDelta: number = 0;
+  let presentationTime: number = 0;
+  let eventDuration: number = 0;
+  let id: number = 0;
+  let offset: number = 0;
+
+  if (version === 0) {
+    while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
+      schemeIdUri += bin2str(data.subarray(offset, offset + 1));
+      offset += 1;
+    }
+
+    schemeIdUri += bin2str(data.subarray(offset, offset + 1));
+    offset += 1;
+
+    while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
+      value += bin2str(data.subarray(offset, offset + 1));
+      offset += 1;
+    }
+
+    value += bin2str(data.subarray(offset, offset + 1));
+    offset += 1;
+
+    timeScale = readUint32(data, 12);
+    presentationTimeDelta = readUint32(data, 16);
+    eventDuration = readUint32(data, 20);
+    id = readUint32(data, 24);
+    offset = 28;
+  } else if (version === 1) {
+    offset += 4;
+    timeScale = readUint32(data, offset);
+    offset += 4;
+    const leftPresentationTime = readUint32(data, offset);
+    offset += 4;
+    const rightPresentationTime = readUint32(data, offset);
+    offset += 4;
+    presentationTime = 2 ** 32 * leftPresentationTime + rightPresentationTime;
+    if (!Number.isSafeInteger(presentationTime)) {
+      presentationTime = Number.MAX_SAFE_INTEGER;
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Presentation time exceeds safe integer limit and wrapped to max safe integer in parsing emsg box'
+      );
+    }
+
+    eventDuration = readUint32(data, offset);
+    offset += 4;
+    id = readUint32(data, offset);
+    offset += 4;
+
+    while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
+      schemeIdUri += bin2str(data.subarray(offset, offset + 1));
+      offset += 1;
+    }
+
+    schemeIdUri += bin2str(data.subarray(offset, offset + 1));
+    offset += 1;
+
+    while (bin2str(data.subarray(offset, offset + 1)) !== '\0') {
+      value += bin2str(data.subarray(offset, offset + 1));
+      offset += 1;
+    }
+
+    value += bin2str(data.subarray(offset, offset + 1));
+    offset += 1;
+  }
+  const payload = data.subarray(offset, data.byteLength);
+
+  return {
+    schemeIdUri,
+    value,
+    timeScale,
+    presentationTime,
+    presentationTimeDelta,
+    eventDuration,
+    id,
+    payload,
+  };
+}
+
 export interface SeiNalUnits {
   payloadType: number;
   payloadSize: number;


### PR DESCRIPTION
This PR will...

Deal Inband Timed Metadata for FMP4 (ID3 within Emsgv1).

Support ID3 within EMSG Scheme:
- 'https://aomedia.org/emsg/ID3',
- 'https://developer.apple.com/streaming/emsg-id3',
- 'urn:scte:scte35:2013:xml'

Resolves issues:
[DORIS-885](https://dicetech.atlassian.net/browse/DORIS-885)
