### PR TITLE
fix: whitelist codecs for v1.2

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1240,6 +1240,9 @@ export type LatencyControllerConfig = {
     liveSyncDuration?: number;
     liveMaxLatencyDuration?: number;
     maxLiveSyncPlaybackRate: number;
+    recoverFromStallPeriod: number;
+    minSmoothPlaybackBuffer: number;
+    enableCatchupLoLP: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "Level" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2217,18 +2220,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:170:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:180:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:181:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:183:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:184:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:185:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:187:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:190:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:192:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:193:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:194:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:195:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:173:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:183:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:184:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:186:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:187:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:188:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:190:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:193:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:195:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:196:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:197:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:198:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1340,6 +1340,7 @@ export interface LevelAttributes extends AttrList {
 // @public (undocumented)
 export type LevelControllerConfig = {
     startLevel?: number;
+    replaceCodecs: [string, string][];
 };
 
 // Warning: (ae-missing-release-tag) "LevelDetails" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2216,18 +2217,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:169:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:179:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:180:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:182:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:183:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:184:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:186:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:189:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:191:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:192:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:193:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:194:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:170:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:180:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:181:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:183:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:184:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:185:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:187:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:190:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:192:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:193:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:194:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:195:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1240,9 +1240,6 @@ export type LatencyControllerConfig = {
     liveSyncDuration?: number;
     liveMaxLatencyDuration?: number;
     maxLiveSyncPlaybackRate: number;
-    recoverFromStallPeriod: number;
-    minSmoothPlaybackBuffer: number;
-    enableCatchupLoLP: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "Level" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2220,18 +2217,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:173:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:183:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:184:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:186:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:187:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:188:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:190:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:193:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:195:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:196:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:197:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:198:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:170:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:180:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:181:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:183:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:184:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:185:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:187:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:190:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:192:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:193:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:194:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:195:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,9 +138,6 @@ export type LatencyControllerConfig = {
   liveSyncDuration?: number;
   liveMaxLatencyDuration?: number;
   maxLiveSyncPlaybackRate: number;
-  recoverFromStallPeriod: number;
-  minSmoothPlaybackBuffer: number;
-  enableCatchupLoLP: boolean;
 };
 
 export type MetadataControllerConfig = {
@@ -238,9 +235,6 @@ export const hlsDefaultConfig: HlsConfig = {
   liveSyncDuration: undefined, // used by latency-controller
   liveMaxLatencyDuration: undefined, // used by latency-controller
   maxLiveSyncPlaybackRate: 1, // used by latency-controller
-  recoverFromStallPeriod: 60000, // used by latency-controller
-  minSmoothPlaybackBuffer: 1, // used by latency-controller
-  enableCatchupLoLP: false, // used by latency-controller
   liveDurationInfinity: false, // used by buffer-controller
   liveBackBufferLength: null, // used by buffer-controller
   maxMaxBufferLength: 600, // used by stream-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,6 +138,9 @@ export type LatencyControllerConfig = {
   liveSyncDuration?: number;
   liveMaxLatencyDuration?: number;
   maxLiveSyncPlaybackRate: number;
+  recoverFromStallPeriod: number;
+  minSmoothPlaybackBuffer: number;
+  enableCatchupLoLP: boolean;
 };
 
 export type MetadataControllerConfig = {
@@ -235,6 +238,9 @@ export const hlsDefaultConfig: HlsConfig = {
   liveSyncDuration: undefined, // used by latency-controller
   liveMaxLatencyDuration: undefined, // used by latency-controller
   maxLiveSyncPlaybackRate: 1, // used by latency-controller
+  recoverFromStallPeriod: 60000, // used by latency-controller
+  minSmoothPlaybackBuffer: 1, // used by latency-controller
+  enableCatchupLoLP: false, // used by latency-controller
   liveDurationInfinity: false, // used by buffer-controller
   liveBackBufferLength: null, // used by buffer-controller
   maxMaxBufferLength: 600, // used by stream-controller

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,7 @@ export type FPSControllerConfig = {
 
 export type LevelControllerConfig = {
   startLevel?: number;
+  replaceCodecs: [string, string][];
 };
 
 export type MP4RemuxerConfig = {
@@ -244,6 +245,7 @@ export const hlsDefaultConfig: HlsConfig = {
   manifestLoadingRetryDelay: 1000, // used by playlist-loader
   manifestLoadingMaxRetryTimeout: 64000, // used by playlist-loader
   startLevel: undefined, // used by level-controller
+  replaceCodecs: [], // used by level-controller
   levelLoadingTimeOut: 10000, // used by playlist-loader
   levelLoadingMaxRetry: 4, // used by playlist-loader
   levelLoadingRetryDelay: 1000, // used by playlist-loader

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -26,11 +26,19 @@ type Cue = VTTCue | TextTrackCue;
 
 const MIN_CUE_DURATION = 0.25;
 
+const isPlayStation4 = () => {
+  return /PlayStation 4/i.test(navigator.userAgent);
+};
+
 function getCueClass() {
   // Attempt to recreate Safari functionality by creating
   // WebKitDataCue objects when available and store the decoded
   // ID3 data in the value property of the cue
-  return (self.WebKitDataCue || self.VTTCue || self.TextTrackCue) as any;
+  // WebKitDataCue exists on PlayStation 4 WebMAF,
+  // but doesn't allow its value to be set.
+  return ((!isPlayStation4() && self.WebKitDataCue) ||
+    self.VTTCue ||
+    self.TextTrackCue) as any;
 }
 
 function dateRangeDateToTimelineSeconds(date: Date, offset: number): number {

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -19,7 +19,6 @@ export default class LatencyController implements ComponentAPI {
   private currentTime: number = 0;
   private stallCount: number = 0;
   private _latency: number | null = null;
-  private _lastStallTime: number = 0;
   private timeupdateHandler = () => this.timeupdate();
 
   constructor(hls: Hls) {
@@ -64,29 +63,6 @@ export default class LatencyController implements ComponentAPI {
     }
     const maxLiveSyncOnStallIncrease = targetduration;
     const liveSyncOnStallIncrease = 1.0;
-
-    // try to recover
-    const { recoverFromStallPeriod, minSmoothPlaybackBuffer } = this.config;
-    if (
-      lowLatencyMode &&
-      this.stallCount > 0 &&
-      Date.now() - this._lastStallTime > recoverFromStallPeriod && // no buffering in certain period
-      this.forwardBufferLength > minSmoothPlaybackBuffer
-    ) {
-      // have enough data
-      this._lastStallTime = Date.now();
-      const maxStallCount = Math.floor(
-        maxLiveSyncOnStallIncrease / liveSyncOnStallIncrease
-      );
-      if (this.stallCount > maxStallCount) {
-        this.stallCount = maxStallCount;
-      }
-      this.stallCount--;
-      logger.warn(
-        '[playback-rate-controller]: Recover from stall, adjusting target latency'
-      );
-    }
-
     return (
       targetLatency +
       Math.min(
@@ -188,7 +164,6 @@ export default class LatencyController implements ComponentAPI {
     this.levelDetails = null;
     this._latency = null;
     this.stallCount = 0;
-    this._lastStallTime = 0;
   }
 
   private onLevelUpdated(
@@ -209,8 +184,6 @@ export default class LatencyController implements ComponentAPI {
       return;
     }
     this.stallCount++;
-    this._lastStallTime = Date.now();
-
     logger.warn(
       '[playback-rate-controller]: Stall detected, adjusting target latency'
     );
@@ -230,12 +203,7 @@ export default class LatencyController implements ComponentAPI {
     this._latency = latency;
 
     // Adapt playbackRate to meet target latency in low-latency mode
-    const {
-      enableCatchupLoLP,
-      lowLatencyMode,
-      maxLiveSyncPlaybackRate,
-      minSmoothPlaybackBuffer,
-    } = this.config;
+    const { lowLatencyMode, maxLiveSyncPlaybackRate } = this.config;
     if (!lowLatencyMode || maxLiveSyncPlaybackRate === 1) {
       return;
     }
@@ -243,36 +211,30 @@ export default class LatencyController implements ComponentAPI {
     if (targetLatency === null) {
       return;
     }
-    // Only adjust playbackRate on browsers for now
-    if (this.canDeviceChangePlaybackRate()) {
-      const newRate = enableCatchupLoLP
-        ? this.calculateNewPlaybackRateLolP(media, latency, targetLatency)
-        : this.calculateNewPlaybackRateDefault(
-            media,
-            latency,
-            targetLatency,
-            levelDetails
-          );
-      if (newRate) {
-        media.playbackRate = newRate;
-      }
-    }
-
-    // seek to live edge
     const distanceFromTarget = latency - targetLatency;
+    // Only adjust playbackRate when within one target duration of targetLatency
+    // and more than one second from under-buffering.
+    // Playback further than one target duration from target can be considered DVR playback.
     const liveMinLatencyDuration = Math.min(
       this.maxLatency,
       targetLatency + levelDetails.targetduration
     );
+    const inLiveRange = distanceFromTarget < liveMinLatencyDuration;
     if (
       levelDetails.live &&
-      this.stallCount === 0 &&
-      this.forwardBufferLength > minSmoothPlaybackBuffer &&
-      distanceFromTarget > liveMinLatencyDuration &&
-      this.liveSyncPosition
+      inLiveRange &&
+      distanceFromTarget > 0.05 &&
+      this.forwardBufferLength > 1
     ) {
-      // alway seek to live sync position when current position is larger enough
-      media.currentTime = this.liveSyncPosition;
+      const max = Math.min(2, Math.max(1.0, maxLiveSyncPlaybackRate));
+      const rate =
+        Math.round(
+          (2 / (1 + Math.exp(-0.75 * distanceFromTarget - this.edgeStalled))) *
+            20
+        ) / 20;
+      media.playbackRate = Math.min(max, Math.max(1, rate));
+    } else if (media.playbackRate !== 1 && media.playbackRate !== 0) {
+      media.playbackRate = 1;
     }
   }
 
@@ -290,107 +252,5 @@ export default class LatencyController implements ComponentAPI {
       return null;
     }
     return liveEdge - this.currentTime;
-  }
-
-  private canDeviceChangePlaybackRate(): boolean {
-    const ua =
-      typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : '';
-    // According to https://bugs.webkit.org/show_bug.cgi?id=208142
-    // changing playbackRate in Safari can cause video playback disruption.
-    const isSafari = /safari/.test(ua) && !/chrome/.test(ua);
-    // Changing playbackRate in some devices also cause video playback disruption.
-    const isDeviceNotSupported = ['xbox', 'web0s', 'tizen'].reduce(
-      (result: boolean, deviceUA: string) => {
-        return result || ua.indexOf(deviceUA) !== -1;
-      },
-      isSafari
-    );
-    return !isDeviceNotSupported;
-  }
-
-  private calculateNewPlaybackRateDefault(
-    media: HTMLMediaElement,
-    latency: number,
-    targetLatency: number,
-    levelDetails: LevelDetails
-  ) {
-    const distanceFromTarget = latency - targetLatency;
-    // Only adjust playbackRate when within one target duration of targetLatency
-    // and more than one second from under-buffering.
-    // Playback further than one target duration from target can be considered DVR playback.
-    const liveMinLatencyDuration = Math.min(
-      this.maxLatency,
-      targetLatency + levelDetails.targetduration
-    );
-    let newRate;
-    const inLiveRange = distanceFromTarget < liveMinLatencyDuration;
-    if (
-      levelDetails.live &&
-      inLiveRange &&
-      distanceFromTarget > 0.05 &&
-      this.forwardBufferLength > 1 &&
-      this.canDeviceChangePlaybackRate() // Only adjust playbackRate on browsers for now
-    ) {
-      const { maxLiveSyncPlaybackRate } = this.config;
-      const max = Math.min(2, Math.max(1.0, maxLiveSyncPlaybackRate));
-      const rate =
-        Math.round(
-          (2 / (1 + Math.exp(-0.75 * distanceFromTarget - this.edgeStalled))) *
-            20
-        ) / 20;
-      newRate = Math.min(max, Math.max(1, rate));
-    } else if (media.playbackRate !== 1 && media.playbackRate !== 0) {
-      newRate = 1;
-    }
-    return newRate;
-  }
-
-  private calculateNewPlaybackRateLolP(
-    media: HTMLMediaElement,
-    latency: number,
-    targetLatency: number
-  ) {
-    const { minSmoothPlaybackBuffer, maxLiveSyncPlaybackRate } = this.config;
-
-    const cpr = maxLiveSyncPlaybackRate - 1;
-    let newRate;
-
-    const bufferLevel = this.forwardBufferLength;
-    // Hybrid: Buffer-based
-    if (bufferLevel < minSmoothPlaybackBuffer) {
-      // Buffer in danger, slow down
-      const deltaBuffer = bufferLevel - minSmoothPlaybackBuffer; // -ve value
-      const d = deltaBuffer * 5;
-
-      // Playback rate must be between (1 - cpr) - (1 + cpr)
-      // ex: if cpr is 0.5, it can have values between 0.5 - 1.5
-      const s = (cpr * 2) / (1 + Math.pow(Math.E, -d));
-      newRate = 1 - cpr + s;
-    } else {
-      // Hybrid: Latency-based
-      // Buffer is safe, vary playback rate based on latency
-
-      // Check if latency is within range of target latency
-      const minDifference = 0.1;
-      if (Math.abs(latency - targetLatency) <= minDifference * targetLatency) {
-        newRate = 1;
-      } else {
-        const deltaLatency = latency - targetLatency;
-        const d = deltaLatency * 5;
-
-        // Playback rate must be between (1 - cpr) - (1 + cpr)
-        // ex: if cpr is 0.5, it can have values between 0.5 - 1.5
-        const s = (cpr * 2) / (1 + Math.pow(Math.E, -d));
-        newRate = 1 - cpr + s;
-      }
-    }
-
-    // don't change playbackrate for small variations (don't overload element with playbackrate changes)
-    const minPlaybackRateChange = 0.02;
-    if (Math.abs(media.playbackRate - newRate) <= minPlaybackRateChange) {
-      newRate = null;
-    }
-
-    return newRate;
   }
 }

--- a/src/controller/latency-controller.ts
+++ b/src/controller/latency-controller.ts
@@ -19,6 +19,7 @@ export default class LatencyController implements ComponentAPI {
   private currentTime: number = 0;
   private stallCount: number = 0;
   private _latency: number | null = null;
+  private _lastStallTime: number = 0;
   private timeupdateHandler = () => this.timeupdate();
 
   constructor(hls: Hls) {
@@ -63,6 +64,29 @@ export default class LatencyController implements ComponentAPI {
     }
     const maxLiveSyncOnStallIncrease = targetduration;
     const liveSyncOnStallIncrease = 1.0;
+
+    // try to recover
+    const { recoverFromStallPeriod, minSmoothPlaybackBuffer } = this.config;
+    if (
+      lowLatencyMode &&
+      this.stallCount > 0 &&
+      Date.now() - this._lastStallTime > recoverFromStallPeriod && // no buffering in certain period
+      this.forwardBufferLength > minSmoothPlaybackBuffer
+    ) {
+      // have enough data
+      this._lastStallTime = Date.now();
+      const maxStallCount = Math.floor(
+        maxLiveSyncOnStallIncrease / liveSyncOnStallIncrease
+      );
+      if (this.stallCount > maxStallCount) {
+        this.stallCount = maxStallCount;
+      }
+      this.stallCount--;
+      logger.warn(
+        '[playback-rate-controller]: Recover from stall, adjusting target latency'
+      );
+    }
+
     return (
       targetLatency +
       Math.min(
@@ -164,6 +188,7 @@ export default class LatencyController implements ComponentAPI {
     this.levelDetails = null;
     this._latency = null;
     this.stallCount = 0;
+    this._lastStallTime = 0;
   }
 
   private onLevelUpdated(
@@ -184,6 +209,8 @@ export default class LatencyController implements ComponentAPI {
       return;
     }
     this.stallCount++;
+    this._lastStallTime = Date.now();
+
     logger.warn(
       '[playback-rate-controller]: Stall detected, adjusting target latency'
     );
@@ -203,7 +230,12 @@ export default class LatencyController implements ComponentAPI {
     this._latency = latency;
 
     // Adapt playbackRate to meet target latency in low-latency mode
-    const { lowLatencyMode, maxLiveSyncPlaybackRate } = this.config;
+    const {
+      enableCatchupLoLP,
+      lowLatencyMode,
+      maxLiveSyncPlaybackRate,
+      minSmoothPlaybackBuffer,
+    } = this.config;
     if (!lowLatencyMode || maxLiveSyncPlaybackRate === 1) {
       return;
     }
@@ -211,30 +243,36 @@ export default class LatencyController implements ComponentAPI {
     if (targetLatency === null) {
       return;
     }
+    // Only adjust playbackRate on browsers for now
+    if (this.canDeviceChangePlaybackRate()) {
+      const newRate = enableCatchupLoLP
+        ? this.calculateNewPlaybackRateLolP(media, latency, targetLatency)
+        : this.calculateNewPlaybackRateDefault(
+            media,
+            latency,
+            targetLatency,
+            levelDetails
+          );
+      if (newRate) {
+        media.playbackRate = newRate;
+      }
+    }
+
+    // seek to live edge
     const distanceFromTarget = latency - targetLatency;
-    // Only adjust playbackRate when within one target duration of targetLatency
-    // and more than one second from under-buffering.
-    // Playback further than one target duration from target can be considered DVR playback.
     const liveMinLatencyDuration = Math.min(
       this.maxLatency,
       targetLatency + levelDetails.targetduration
     );
-    const inLiveRange = distanceFromTarget < liveMinLatencyDuration;
     if (
       levelDetails.live &&
-      inLiveRange &&
-      distanceFromTarget > 0.05 &&
-      this.forwardBufferLength > 1
+      this.stallCount === 0 &&
+      this.forwardBufferLength > minSmoothPlaybackBuffer &&
+      distanceFromTarget > liveMinLatencyDuration &&
+      this.liveSyncPosition
     ) {
-      const max = Math.min(2, Math.max(1.0, maxLiveSyncPlaybackRate));
-      const rate =
-        Math.round(
-          (2 / (1 + Math.exp(-0.75 * distanceFromTarget - this.edgeStalled))) *
-            20
-        ) / 20;
-      media.playbackRate = Math.min(max, Math.max(1, rate));
-    } else if (media.playbackRate !== 1 && media.playbackRate !== 0) {
-      media.playbackRate = 1;
+      // alway seek to live sync position when current position is larger enough
+      media.currentTime = this.liveSyncPosition;
     }
   }
 
@@ -252,5 +290,107 @@ export default class LatencyController implements ComponentAPI {
       return null;
     }
     return liveEdge - this.currentTime;
+  }
+
+  private canDeviceChangePlaybackRate(): boolean {
+    const ua =
+      typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase() : '';
+    // According to https://bugs.webkit.org/show_bug.cgi?id=208142
+    // changing playbackRate in Safari can cause video playback disruption.
+    const isSafari = /safari/.test(ua) && !/chrome/.test(ua);
+    // Changing playbackRate in some devices also cause video playback disruption.
+    const isDeviceNotSupported = ['xbox', 'web0s', 'tizen'].reduce(
+      (result: boolean, deviceUA: string) => {
+        return result || ua.indexOf(deviceUA) !== -1;
+      },
+      isSafari
+    );
+    return !isDeviceNotSupported;
+  }
+
+  private calculateNewPlaybackRateDefault(
+    media: HTMLMediaElement,
+    latency: number,
+    targetLatency: number,
+    levelDetails: LevelDetails
+  ) {
+    const distanceFromTarget = latency - targetLatency;
+    // Only adjust playbackRate when within one target duration of targetLatency
+    // and more than one second from under-buffering.
+    // Playback further than one target duration from target can be considered DVR playback.
+    const liveMinLatencyDuration = Math.min(
+      this.maxLatency,
+      targetLatency + levelDetails.targetduration
+    );
+    let newRate;
+    const inLiveRange = distanceFromTarget < liveMinLatencyDuration;
+    if (
+      levelDetails.live &&
+      inLiveRange &&
+      distanceFromTarget > 0.05 &&
+      this.forwardBufferLength > 1 &&
+      this.canDeviceChangePlaybackRate() // Only adjust playbackRate on browsers for now
+    ) {
+      const { maxLiveSyncPlaybackRate } = this.config;
+      const max = Math.min(2, Math.max(1.0, maxLiveSyncPlaybackRate));
+      const rate =
+        Math.round(
+          (2 / (1 + Math.exp(-0.75 * distanceFromTarget - this.edgeStalled))) *
+            20
+        ) / 20;
+      newRate = Math.min(max, Math.max(1, rate));
+    } else if (media.playbackRate !== 1 && media.playbackRate !== 0) {
+      newRate = 1;
+    }
+    return newRate;
+  }
+
+  private calculateNewPlaybackRateLolP(
+    media: HTMLMediaElement,
+    latency: number,
+    targetLatency: number
+  ) {
+    const { minSmoothPlaybackBuffer, maxLiveSyncPlaybackRate } = this.config;
+
+    const cpr = maxLiveSyncPlaybackRate - 1;
+    let newRate;
+
+    const bufferLevel = this.forwardBufferLength;
+    // Hybrid: Buffer-based
+    if (bufferLevel < minSmoothPlaybackBuffer) {
+      // Buffer in danger, slow down
+      const deltaBuffer = bufferLevel - minSmoothPlaybackBuffer; // -ve value
+      const d = deltaBuffer * 5;
+
+      // Playback rate must be between (1 - cpr) - (1 + cpr)
+      // ex: if cpr is 0.5, it can have values between 0.5 - 1.5
+      const s = (cpr * 2) / (1 + Math.pow(Math.E, -d));
+      newRate = 1 - cpr + s;
+    } else {
+      // Hybrid: Latency-based
+      // Buffer is safe, vary playback rate based on latency
+
+      // Check if latency is within range of target latency
+      const minDifference = 0.1;
+      if (Math.abs(latency - targetLatency) <= minDifference * targetLatency) {
+        newRate = 1;
+      } else {
+        const deltaLatency = latency - targetLatency;
+        const d = deltaLatency * 5;
+
+        // Playback rate must be between (1 - cpr) - (1 + cpr)
+        // ex: if cpr is 0.5, it can have values between 0.5 - 1.5
+        const s = (cpr * 2) / (1 + Math.pow(Math.E, -d));
+        newRate = 1 - cpr + s;
+      }
+    }
+
+    // don't change playbackrate for small variations (don't overload element with playbackrate changes)
+    const minPlaybackRateChange = 0.02;
+    if (Math.abs(media.playbackRate - newRate) <= minPlaybackRateChange) {
+      newRate = null;
+    }
+
+    return newRate;
   }
 }

--- a/src/controller/level-controller.ts
+++ b/src/controller/level-controller.ts
@@ -99,6 +99,17 @@ export default class LevelController extends BasePlaylistController {
       videoCodecFound = videoCodecFound || !!levelParsed.videoCodec;
       audioCodecFound = audioCodecFound || !!levelParsed.audioCodec;
 
+      // replace codecs with the ones defined as supported by this browser
+      const { replaceCodecs } = this.hls.config;
+      for (const [from, to] of replaceCodecs) {
+        if (levelParsed.videoCodec?.toLowerCase() === from.toLowerCase()) {
+          levelParsed.videoCodec = to;
+        }
+        if (levelParsed.audioCodec?.toLowerCase() === from.toLowerCase()) {
+          levelParsed.audioCodec = to;
+        }
+      }
+
       // erase audio codec info if browser does not support mp4a.40.34.
       // demuxer will autodetect codec and fallback to mpeg/audio
       if (


### PR DESCRIPTION
### This PR will...

Fix issue [DORIS-1354](https://dicetech.atlassian.net/browse/DORIS-1354)

- Avoid using WebKitDataCue on PlayStation 4, as it's value is readonly

- Adds replaceCodecs to level controller config.

Allows codecs to be replaced by less specific versions. Useful on PlayStation 4 where AVC High Profile can be played back, but MSE is rejecting it's codec string.

```
Example:
{
    replaceCodecs: [
        ['avc1.640029', 'avc1']
    ]
},
```
