### PR TITLE
fix: ensure cues are displayed in correct order

### DIFF
--- a/src/utils/cues.ts
+++ b/src/utils/cues.ts
@@ -66,7 +66,13 @@ const Cues: CuesInterface = {
         if (!track || !track.cues || !track.cues.getCueById(id)) {
           cue = new Cue(startTime, endTime, cueText);
           cue.id = id;
-          cue.line = r + 1;
+          // VTTCue.line get's flakey when using controls, so let's now include line 13&14
+          // also, drop line 1 since it's to close to the top
+          if (navigator.userAgent.match(/Firefox\//)) {
+            cue.line = r + 1;
+          } else {
+            cue.line = r > 7 ? r - 2 : r + 1;
+          }
           cue.align = 'left';
           // Clamp the position between 10 and 80 percent (CEA-608 PAC indent code)
           // https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#positioning-in-cea-608
@@ -77,16 +83,7 @@ const Cues: CuesInterface = {
       }
     }
     if (track && result.length) {
-      // Sort bottom cues in reverse order so that they render in line order when overlapping in Chrome
-      result.sort((cueA, cueB) => {
-        if (cueA.line === 'auto' || cueB.line === 'auto') {
-          return 0;
-        }
-        if (cueA.line > 8 && cueB.line > 8) {
-          return cueB.line - cueA.line;
-        }
-        return cueA.line - cueB.line;
-      });
+      // Remove sort for doris. The cue's line is ignored in doris player.
       result.forEach((cue) => addCueToTrack(track, cue));
     }
     return result;


### PR DESCRIPTION
### This PR will...

Fix issue [DORIS-1358](https://dicetech.atlassian.net/browse/DORIS-1358)

- Ensure cues are displayed in correct order (oldest -> latest) with doris-test-player.

