### PR TITLE
fix: Cannot get correct video initial pts for audio demuxer

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -609,7 +609,9 @@ export enum Events {
     // (undocumented)
     SUBTITLE_TRACKS_CLEARED = "hlsSubtitleTracksCleared",
     // (undocumented)
-    SUBTITLE_TRACKS_UPDATED = "hlsSubtitleTracksUpdated"
+    SUBTITLE_TRACKS_UPDATED = "hlsSubtitleTracksUpdated",
+    // (undocumented)
+    VIDEO_PTS_NEEDED = "hlsVideoPtsNeeded"
 }
 
 // Warning: (ae-missing-release-tag) "FPSControllerConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1144,6 +1146,10 @@ export interface HlsListeners {
     [Events.SUBTITLE_TRACKS_UPDATED]: (event: Events.SUBTITLE_TRACKS_UPDATED, data: SubtitleTracksUpdatedData) => void;
     // (undocumented)
     [Events.SUBTITLE_TRACK_SWITCH]: (event: Events.SUBTITLE_TRACK_SWITCH, data: SubtitleTrackSwitchData) => void;
+    // Warning: (ae-forgotten-export) The symbol "VideoPTSNeededCC" needs to be exported by the entry point hls.d.ts
+    //
+    // (undocumented)
+    [Events.VIDEO_PTS_NEEDED]: (event: Events.VIDEO_PTS_NEEDED, data: VideoPTSNeededCC) => void;
 }
 
 // Warning: (ae-missing-release-tag) "HlsPerformanceTiming" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -48,10 +48,13 @@ class AudioStreamController
   implements NetworkComponentAPI
 {
   private videoBuffer: any | null = null;
+  /** The current CC of the video track. */
   private videoTrackCC: number = -1;
+  /** The CC of the video track at the time `this.waitingData` was put on hold. */
   private waitingVideoCC: number = -1;
   private audioSwitch: boolean = false;
   private trackId: number = -1;
+  /** A pending audio fragment that loaded but cannot be buffered yet as it's initPTS is unknown. */
   private waitingData: WaitingForPTSData | null = null;
   private mainDetails: LevelDetails | null = null;
   private bufferFlushed: boolean = false;
@@ -161,7 +164,7 @@ class AudioStreamController
           if (this.waitForCdnTuneIn(details)) {
             break;
           }
-          this.state = State.WAITING_INIT_PTS;
+          this.state = State.IDLE;
         }
         break;
       }
@@ -183,6 +186,7 @@ class AudioStreamController
           if (this.initPTS[frag.cc] !== undefined) {
             this.waitingData = null;
             this.waitingVideoCC = -1;
+            this.videoTrackCC = -1;
             this.state = State.FRAG_LOADING;
             const payload = cache.flush();
             const data: FragLoadedData = {
@@ -219,6 +223,10 @@ class AudioStreamController
                 `Waiting fragment cc (${frag.cc}) @ ${frag.start} cancelled because another fragment at ${bufferInfo.end} is needed`
               );
               this.clearWaitingFragment();
+            } else {
+              if (this.waitingVideoCC !== -1 && frag.cc < this.waitingVideoCC) {
+                this.hls.trigger(Events.VIDEO_PTS_NEEDED, { cc: frag.cc });
+              }
             }
           }
         } else {
@@ -821,11 +829,6 @@ class AudioStreamController
     ) {
       if (frag.sn === 'initSegment') {
         this._loadInitSegment(frag);
-      } else if (trackDetails.live && !Number.isFinite(this.initPTS[frag.cc])) {
-        this.log(
-          `Waiting for video PTS in continuity counter ${frag.cc} of live stream before loading audio fragment ${frag.sn} of level ${this.trackId}`
-        );
-        this.state = State.WAITING_INIT_PTS;
       } else {
         this.startFragRequested = true;
         super.loadFragment(frag, trackDetails, targetBufferTime);

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -90,6 +90,7 @@ export default class BaseStreamController
   protected startFragRequested: boolean = false;
   protected decrypter: Decrypter;
   protected initPTS: Array<number> = [];
+  protected reAlignCC: number | null = null;
   protected onvseeking: EventListener | null = null;
   protected onvended: EventListener | null = null;
 
@@ -989,19 +990,35 @@ export default class BaseStreamController
     }
 
     let frag;
-    if (bufferEnd < end) {
-      const lookupTolerance = bufferEnd > end - tolerance ? 0 : tolerance;
-      // Remove the tolerance if it would put the bufferEnd past the actual end of stream
-      // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
-      frag = findFragmentByPTS(
-        fragPrevious,
-        fragments,
-        bufferEnd,
-        lookupTolerance
+    if (this.reAlignCC != null && this.fragPrevious?.cc !== this.reAlignCC) {
+      const fragmentsWithMatchingCC = fragments.filter(
+        (fragment) => fragment.cc === this.reAlignCC
       );
-    } else {
-      // reach end of playlist
-      frag = fragments[fragments.length - 1];
+
+      // Use the last fragment with matching CC as this issue generally occurs at the end of discontinuities
+      // with slightly offset audio / video manifests.
+      frag = fragmentsWithMatchingCC[fragmentsWithMatchingCC.length - 1];
+      this.reAlignCC = null;
+      logger.info(
+        `Loading video segment ${frag.sn} (cc: ${frag.cc}) to get initPTS for audio-stream-controller.`
+      );
+    }
+
+    if (!frag) {
+      if (bufferEnd < end) {
+        const lookupTolerance = bufferEnd > end - tolerance ? 0 : tolerance;
+        // Remove the tolerance if it would put the bufferEnd past the actual end of stream
+        // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
+        frag = findFragmentByPTS(
+          fragPrevious,
+          fragments,
+          bufferEnd,
+          lookupTolerance
+        );
+      } else {
+        // reach end of playlist
+        frag = fragments[fragments.length - 1];
+      }
     }
 
     if (frag) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -34,6 +34,7 @@ import type {
   LevelsUpdatedData,
   ManifestParsedData,
   MediaAttachedData,
+  VideoPTSNeededCC,
 } from '../types/events';
 
 const TICK_INTERVAL = 100; // how often to tick in ms
@@ -83,6 +84,7 @@ export default class StreamController
     hls.on(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
     hls.on(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.on(Events.FRAG_BUFFERED, this.onFragBuffered, this);
+    hls.on(Events.VIDEO_PTS_NEEDED, this.onVideoPtsNeeded, this);
   }
 
   protected _unregisterListeners() {
@@ -104,6 +106,7 @@ export default class StreamController
     hls.off(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
     hls.off(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.off(Events.FRAG_BUFFERED, this.onFragBuffered, this);
+    hls.off(Events.VIDEO_PTS_NEEDED, this.onVideoPtsNeeded, this);
   }
 
   protected onHandlerDestroying() {
@@ -1398,5 +1401,9 @@ export default class StreamController
 
   get forceStartLoad() {
     return this._forceStartLoad;
+  }
+
+  onVideoPtsNeeded(event: Events.VIDEO_PTS_NEEDED, data: VideoPTSNeededCC) {
+    this.reAlignCC = data.cc;
   }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -47,6 +47,7 @@ import {
   LiveBackBufferData,
   TrackLoadingData,
   BufferFlushedData,
+  VideoPTSNeededCC,
 } from './types/events';
 
 /**
@@ -166,6 +167,8 @@ export enum Events {
   LIVE_BACK_BUFFER_REACHED = 'hlsLiveBackBufferReached',
   // fired when the back buffer is reached as defined by the backBufferLength config option - data : { bufferEnd: number }
   BACK_BUFFER_REACHED = 'hlsBackBufferReached',
+  // fired when audio stream controller is stuck and requires video PTS to be available for a continuity, this is a temporary fix until v1
+  VIDEO_PTS_NEEDED = 'hlsVideoPtsNeeded',
 }
 
 export interface HlsListeners {
@@ -361,6 +364,10 @@ export interface HlsListeners {
   [Events.BACK_BUFFER_REACHED]: (
     event: Events.BACK_BUFFER_REACHED,
     data: BackBufferData
+  ) => void;
+  [Events.VIDEO_PTS_NEEDED]: (
+    event: Events.VIDEO_PTS_NEEDED,
+    data: VideoPTSNeededCC
   ) => void;
 }
 export interface HlsEventEmitter {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -72,6 +72,10 @@ export interface BufferFlushedData {
   type: SourceBufferName;
 }
 
+export interface VideoPTSNeededCC {
+  cc: number;
+}
+
 export interface ManifestLoadingData {
   url: string;
 }


### PR DESCRIPTION
### This PR will...

Fix issue [DORIS-1350](https://dicetech.atlassian.net/browse/DORIS-1350)

- Initial buffering near discontinuities.

- Initial audio segment is no longer rebuffered continuously until the first video fragment is buffered.