### PR TITLE
fix: Use id in manifest instead of id in SCTE35 binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hls.js",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hls.js",
-      "version": "1.2.11",
+      "version": "1.2.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/id3-track-controller.ts
+++ b/src/controller/id3-track-controller.ts
@@ -371,6 +371,7 @@ class ID3TrackController implements ComponentAPI {
           }
           cue.value = { key, data };
           cue.type = MetadataSchema.dateRange;
+          cue.id = id;
           this.id3Track.addCue(cue);
           cues[key] = cue;
         }


### PR DESCRIPTION
This PR will...

Fix issue [DORIS-1618](https://dicetech.atlassian.net/browse/DORIS-1618)

Use id in manifest instead of id in scte35 binary.

[DORIS-1618]: https://dicetech.atlassian.net/browse/DORIS-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ