### PR TITLE
Fix/filtered vtt cues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hls.js",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hls.js",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/utils/texttrack-utils.ts
+++ b/src/utils/texttrack-utils.ts
@@ -13,6 +13,25 @@ export function sendAddTrackEvent(track: TextTrack, videoEl: HTMLMediaElement) {
   videoEl.dispatchEvent(event);
 }
 
+function containsCue(track: TextTrack, cue: VTTCue) {
+  if (!track.cues) {
+    return false;
+  }
+
+  for (let i = 0; i < track.cues.length; i++) {
+    const cueInTextTrack = track.cues[i] as VTTCue;
+    if (
+      cueInTextTrack.startTime === cue.startTime &&
+      cueInTextTrack.endTime === cue.endTime &&
+      cueInTextTrack.text === cue.text
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function addCueToTrack(track: TextTrack, cue: VTTCue) {
   // Sometimes there are cue overlaps on segmented vtts so the same
   // cue can appear more than once in different vtt files.
@@ -21,7 +40,8 @@ export function addCueToTrack(track: TextTrack, cue: VTTCue) {
   if (mode === 'disabled') {
     track.mode = 'hidden';
   }
-  if (track.cues && !track.cues.getCueById(cue.id)) {
+
+  if (track.cues && !containsCue(track, cue)) {
     try {
       track.addCue(cue);
       if (!track.cues.getCueById(cue.id)) {


### PR DESCRIPTION
Avoid filtering out VTTCues with matching ids like:
```
Q0
00:08:48.583 --> 00:08:53.125 line:77%
<c.Q0>We haven't even had auditions yet.</c>

Q0
00:08:48.584 --> 00:08:53.125 line:84%
<c.Q0>Don't assume the lead roles have been decided.</c>
```
