### PR TITLE
Fix/doris 2701 webOS 5 startup improvements (unwanted seek)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hls.js",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hls.js",
-      "version": "1.5.14",
+      "version": "1.5.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -1349,8 +1349,13 @@ export default class BaseStreamController
     if (!media) {
       return;
     }
+
     const liveSyncPosition = this.hls.liveSyncPosition;
-    const currentTime = media.currentTime;
+    const mediaCurrentTime = media.currentTime;
+    const currentTime =
+      this.loadedmetadata || mediaCurrentTime > 0
+        ? mediaCurrentTime
+        : this.startPosition;
     const start = levelDetails.fragments[0].start;
     const end = levelDetails.edge;
     const withinSlidingWindow =
@@ -1376,12 +1381,12 @@ export default class BaseStreamController
         }
         // Only seek if ready and there is not a significant forward buffer available for playback
         if (media.readyState) {
+          const reason =
+            !withinSlidingWindow && media.readyState < 4
+              ? 'outside'
+              : 'too far from the end';
           this.warn(
-            `Playback: ${currentTime.toFixed(
-              3,
-            )} is located too far from the end of live sliding playlist: ${end}, reset currentTime to : ${liveSyncPosition.toFixed(
-              3,
-            )}`,
+            `Playback: ${currentTime.toFixed(3)} is located ${reason} of live sliding playlist: ${start.toFixed(3)} - ${end.toFixed(3)}, reset currentTime to : ${liveSyncPosition.toFixed(3)}`,
           );
           media.currentTime = liveSyncPosition;
         }

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -688,7 +688,10 @@ export default class StreamController
 
     if (!this.startFragRequested) {
       this.setStartPosition(newDetails, sliding);
-    } else if (newDetails.live) {
+    } else if (newDetails.live && this.loadedmetadata) {
+      // Only synchronize live playlists if the metadata is available. This is to avoid race conditions
+      // where the currentTime is not yet adjusted to start position and synchronizeToLiveEdge would cause
+      // the initially loaded segment to be needlessly discarded.
       this.synchronizeToLiveEdge(newDetails);
     }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -688,10 +688,7 @@ export default class StreamController
 
     if (!this.startFragRequested) {
       this.setStartPosition(newDetails, sliding);
-    } else if (newDetails.live && this.loadedmetadata) {
-      // Only synchronize live playlists if the metadata is available. This is to avoid race conditions
-      // where the currentTime is not yet adjusted to start position and synchronizeToLiveEdge would cause
-      // the initially loaded segment to be needlessly discarded.
+    } else if (newDetails.live) {
       this.synchronizeToLiveEdge(newDetails);
     }
 


### PR DESCRIPTION
### This PR will...

Fix issues on webOS 5 where an unnecessary seek is performed during startup if the manifest is updated while the first segment is being buffered.

https://github.com/video-dev/hls.js/issues/6998

Video demonstrating the issue where `synchronizeToLiveEdge` is triggered as soon as the first segment start getting inserted into the source buffer, but the `currentTime` is not yet adjusted to start position.

https://github.com/user-attachments/assets/814156be-5f0d-4266-8236-e340284dba1c



