### PR TITLE
Fix/clear to encrypted transition

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -956,7 +956,7 @@ export type EMEControllerConfig = {
     drmSystems: DRMSystemsConfiguration;
     drmSystemOptions: DRMSystemOptions;
     requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
-    requireKeySystemAccessOnStart?: boolean;
+    requireKeySystemAccessOnStart: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "ErrorActionFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -956,7 +956,7 @@ export type EMEControllerConfig = {
     drmSystems: DRMSystemsConfiguration;
     drmSystemOptions: DRMSystemOptions;
     requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
-    experimentalKeySystemAccessForClearContent?: boolean;
+    requireKeySystemAccessOnStart?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "ErrorActionFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -941,6 +941,8 @@ export class EMEController implements ComponentAPI {
     loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext>;
     // (undocumented)
     selectKeySystemFormat(frag: Fragment): Promise<KeySystemFormats>;
+    // (undocumented)
+    test_selectKeySystemFromConfig(keySystemsToAttempt: KeySystems[]): Promise<KeySystemFormats>;
 }
 
 // Warning: (ae-missing-release-tag) "EMEControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -940,9 +940,9 @@ export class EMEController implements ComponentAPI {
     // (undocumented)
     loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext>;
     // (undocumented)
-    selectKeySystemFormat(frag: Fragment): Promise<KeySystemFormats>;
+    selectKeySystem(keySystemsToAttempt: KeySystems[]): Promise<KeySystemFormats>;
     // (undocumented)
-    test_selectKeySystemFromConfig(keySystemsToAttempt: KeySystems[]): Promise<KeySystemFormats>;
+    selectKeySystemFormat(frag: Fragment): Promise<KeySystemFormats>;
 }
 
 // Warning: (ae-missing-release-tag) "EMEControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -956,6 +956,7 @@ export type EMEControllerConfig = {
     drmSystems: DRMSystemsConfiguration;
     drmSystemOptions: DRMSystemOptions;
     requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
+    experimentalKeySystemAccessForClearContent?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "ErrorActionFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hls.js",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hls.js",
-      "version": "1.5.15",
+      "version": "1.5.16",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,7 @@ export type EMEControllerConfig = {
   drmSystems: DRMSystemsConfiguration;
   drmSystemOptions: DRMSystemOptions;
   requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
+  experimentalKeySystemAccessForClearContent?: boolean;
 };
 
 export interface FragmentLoaderConstructor {

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,7 +122,7 @@ export type EMEControllerConfig = {
   drmSystems: DRMSystemsConfiguration;
   drmSystemOptions: DRMSystemOptions;
   requestMediaKeySystemAccessFunc: MediaKeyFunc | null;
-  experimentalKeySystemAccessForClearContent?: boolean;
+  requireKeySystemAccessOnStart: boolean;
 };
 
 export interface FragmentLoaderConstructor {
@@ -407,6 +407,7 @@ export const hlsDefaultConfig: HlsConfig = {
   requestMediaKeySystemAccessFunc: __USE_EME_DRM__
     ? requestMediaKeySystemAccess
     : null, // used by eme-controller
+  requireKeySystemAccessOnStart: false, // used by eme-controller
   testBandwidth: true,
   progressive: false,
   lowLatencyMode: true,

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -666,9 +666,6 @@ export default class BaseStreamController
       this.fragCurrent = frag;
       keyLoadingPromise = this.keyLoader.load(frag).then((keyLoadedData) => {
         if (!this.fragContextChanged(keyLoadedData.frag)) {
-          this.log(
-            'Emitting KEY_LOADED event without key info - blame this if something goes wrong',
-          );
           this.hls.trigger(Events.KEY_LOADED, keyLoadedData);
           if (this.state === State.KEY_LOADING) {
             this.state = State.IDLE;

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -709,11 +709,10 @@ export default class BaseStreamController
           );
         }
       } else if (details.encryptedFragments.length) {
+        // TODO: this should also move the state to KEY_LOADING, as we can't buffer unencrypted segments before media keys are set
         this.keyLoader.loadClear(frag, details.encryptedFragments);
       }
     }
-    // else if (!frag.encrypted && details.encryptedFragments.length) {
-    // }
 
     targetBufferTime = Math.max(frag.start, targetBufferTime || 0);
     if (this.config.lowLatencyMode && frag.sn !== 'initSegment') {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -685,6 +685,8 @@ export default class BaseStreamController
         details.encryptedFragments,
       );
       if (keyLoadingPromise) {
+        // TODO: This gets logged on every clear segment load regardless of having key system initialized.
+        // keyLoader.loadClear should be optimized to not return a promise if we don't need to wait for key system access.
         this.log(`[eme] blocking frag load until media-keys acquired`);
       }
     }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -680,28 +680,12 @@ export default class BaseStreamController
         );
       }
     } else if (!frag.encrypted) {
-      this.log(
-        `Loading clear ${frag.sn} of [${details.startSN}-${details.endSN}] ${details.encryptedFragments.length ? 'with' : 'without'} encrypted segments in the manifest`,
-      );
-      const keyLoadPromise = this.keyLoader.loadClear(
+      keyLoadingPromise = this.keyLoader.loadClear(
         frag,
         details.encryptedFragments,
       );
-      if (keyLoadPromise) {
-        this.state = State.KEY_LOADING;
-        this.fragCurrent = frag;
-        // Note: Omitted KEY_LOADING event here as we didn't have that for loadClear
-        keyLoadingPromise = keyLoadPromise.then(() => {
-          // TODO: Not sure about this. Do we need to check if the current fragment changed?
-          // For clear segments even if we get the first encrypted fragment back, that won't
-          // match the current fragment of the stream controller.
-          if (!this.fragContextChanged(frag)) {
-            // Note: Omitted KEY_LOADED event here as we didn't have that for loadClear
-            if (this.state === State.KEY_LOADING) {
-              this.state = State.IDLE;
-            }
-          }
-        });
+      if (keyLoadingPromise) {
+        this.log(`[eme] blocking frag load until media-keys acquired`);
       }
     }
 

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -49,7 +49,6 @@ import type { HlsConfig } from '../config';
 import type { NetworkComponentAPI } from '../types/component-api';
 import type { SourceBufferName } from '../types/buffer';
 import type { RationalTimestamp } from '../utils/timescale-conversion';
-import { getKeySystemsForConfig } from '../utils/mediakeys-helper';
 
 type ResolveFragLoaded = (FragLoadedEndData) => void;
 type RejectFragLoaded = (LoadError) => void;
@@ -684,33 +683,28 @@ export default class BaseStreamController
         );
       }
     } else if (!frag.encrypted) {
-      const keySystemsInConfig = getKeySystemsForConfig(this.config);
-      if (keySystemsInConfig.length) {
-        this.log(
-          `Loading keys from config ${JSON.stringify(keySystemsInConfig)}`,
-        );
+      this.log(
+        `Loading clear ${frag.sn} of [${details.startSN}-${details.endSN}] ${details.encryptedFragments.length ? 'with' : 'without'} encrypted segments in the manifest`,
+      );
+      const keyLoadPromise = this.keyLoader.loadClear(
+        frag,
+        details.encryptedFragments,
+      );
+      if (keyLoadPromise) {
         this.state = State.KEY_LOADING;
         this.fragCurrent = frag;
-        keyLoadingPromise = this.keyLoader
-          .test_loadKeysBeforeFragLoad(frag, keySystemsInConfig)
-          .then((keyLoadedData) => {
-            if (!this.fragContextChanged(keyLoadedData.frag)) {
-              this.hls.trigger(Events.KEY_LOADED, keyLoadedData);
-              if (this.state === State.KEY_LOADING) {
-                this.state = State.IDLE;
-              }
-              return keyLoadedData;
+        // Note: Omitted KEY_LOADING event here as we didn't have that for loadClear
+        keyLoadingPromise = keyLoadPromise.then(() => {
+          // TODO: Not sure about this. Do we need to check if the current fragment changed?
+          // For clear segments even if we get the first encrypted fragment back, that won't
+          // match the current fragment of the stream controller.
+          if (!this.fragContextChanged(frag)) {
+            // Note: Omitted KEY_LOADED event here as we didn't have that for loadClear
+            if (this.state === State.KEY_LOADING) {
+              this.state = State.IDLE;
             }
-          });
-        this.hls.trigger(Events.KEY_LOADING, { frag });
-        if (this.fragCurrent === null) {
-          keyLoadingPromise = Promise.reject(
-            new Error(`frag load aborted, context changed in KEY_LOADING`),
-          );
-        }
-      } else if (details.encryptedFragments.length) {
-        // TODO: this should also move the state to KEY_LOADING, as we can't buffer unencrypted segments before media keys are set
-        this.keyLoader.loadClear(frag, details.encryptedFragments);
+          }
+        });
       }
     }
 

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -396,6 +396,25 @@ class EMEController implements ComponentAPI {
     return this.keyFormatPromise;
   }
 
+  public test_selectKeySystemFromConfig(
+    keySystemsToAttempt: KeySystems[],
+  ): Promise<KeySystemFormats> {
+    return new Promise((resolve, reject) => {
+      return this.getKeySystemSelectionPromise(keySystemsToAttempt)
+        .then(({ keySystem }) => {
+          const keySystemFormat = keySystemToKeySystemFormat(keySystem);
+          if (keySystemFormat) {
+            resolve(keySystemFormat);
+          } else {
+            reject(
+              new Error(`Unable to find format for key-system "${keySystem}"`),
+            );
+          }
+        })
+        .catch(reject);
+    });
+  }
+
   private getKeyFormatPromise(
     keyFormats: KeySystemFormats[],
   ): Promise<KeySystemFormats> {

--- a/src/controller/eme-controller.ts
+++ b/src/controller/eme-controller.ts
@@ -383,20 +383,7 @@ class EMEController implements ComponentAPI {
     return keySession.update(data);
   }
 
-  public selectKeySystemFormat(frag: Fragment): Promise<KeySystemFormats> {
-    const keyFormats = Object.keys(frag.levelkeys || {}) as KeySystemFormats[];
-    if (!this.keyFormatPromise) {
-      this.log(
-        `Selecting key-system from fragment (sn: ${frag.sn} ${frag.type}: ${
-          frag.level
-        }) key formats ${keyFormats.join(', ')}`,
-      );
-      this.keyFormatPromise = this.getKeyFormatPromise(keyFormats);
-    }
-    return this.keyFormatPromise;
-  }
-
-  public test_selectKeySystemFromConfig(
+  public selectKeySystem(
     keySystemsToAttempt: KeySystems[],
   ): Promise<KeySystemFormats> {
     return new Promise((resolve, reject) => {
@@ -415,29 +402,30 @@ class EMEController implements ComponentAPI {
     });
   }
 
+  public selectKeySystemFormat(frag: Fragment): Promise<KeySystemFormats> {
+    const keyFormats = Object.keys(frag.levelkeys || {}) as KeySystemFormats[];
+    if (!this.keyFormatPromise) {
+      this.log(
+        `Selecting key-system from fragment (sn: ${frag.sn} ${frag.type}: ${
+          frag.level
+        }) key formats ${keyFormats.join(', ')}`,
+      );
+      this.keyFormatPromise = this.getKeyFormatPromise(keyFormats);
+    }
+    return this.keyFormatPromise;
+  }
+
   private getKeyFormatPromise(
     keyFormats: KeySystemFormats[],
   ): Promise<KeySystemFormats> {
-    return new Promise((resolve, reject) => {
-      const keySystemsInConfig = getKeySystemsForConfig(this.config);
-      const keySystemsToAttempt = keyFormats
-        .map(keySystemFormatToKeySystemDomain)
-        .filter(
-          (value) => !!value && keySystemsInConfig.indexOf(value) !== -1,
-        ) as any as KeySystems[];
-      return this.getKeySystemSelectionPromise(keySystemsToAttempt)
-        .then(({ keySystem }) => {
-          const keySystemFormat = keySystemToKeySystemFormat(keySystem);
-          if (keySystemFormat) {
-            resolve(keySystemFormat);
-          } else {
-            reject(
-              new Error(`Unable to find format for key-system "${keySystem}"`),
-            );
-          }
-        })
-        .catch(reject);
-    });
+    const keySystemsInConfig = getKeySystemsForConfig(this.config);
+    const keySystemsToAttempt = keyFormats
+      .map(keySystemFormatToKeySystemDomain)
+      .filter(
+        (value) => !!value && keySystemsInConfig.indexOf(value) !== -1,
+      ) as any as KeySystems[];
+
+    return this.selectKeySystem(keySystemsToAttempt);
   }
 
   public loadKey(data: KeyLoadedData): Promise<MediaKeySessionContext> {

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -91,7 +91,7 @@ export default class KeyLoader implements ComponentAPI {
   loadClear(
     loadingFrag: Fragment,
     encryptedFragments: Fragment[],
-  ): void | Promise<void> {
+  ): null | Promise<void> {
     if (this.emeController && this.config.emeEnabled) {
       // access key-system with nearest key on start (loading frag is unencrypted)
       if (encryptedFragments.length) {
@@ -109,7 +109,7 @@ export default class KeyLoader implements ComponentAPI {
               });
           }
         }
-      } else if (this.config.experimentalKeySystemAccessForClearContent) {
+      } else if (this.config.requireKeySystemAccessOnStart) {
         const keySystemsInConfig = getKeySystemsForConfig(this.config);
         if (keySystemsInConfig.length) {
           return this.emeController
@@ -120,6 +120,7 @@ export default class KeyLoader implements ComponentAPI {
         }
       }
     }
+    return null;
   }
 
   load(frag: Fragment): Promise<KeyLoadedData> {

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -16,7 +16,8 @@ import type { KeyLoadedData } from '../types/events';
 import type { LevelKey } from './level-key';
 import type EMEController from '../controller/eme-controller';
 import type { MediaKeySessionContext } from '../controller/eme-controller';
-import type { KeySystemFormats, KeySystems } from '../utils/mediakeys-helper';
+import { getKeySystemsForConfig } from '../utils/mediakeys-helper';
+import type { KeySystemFormats } from '../utils/mediakeys-helper';
 
 export interface KeyLoaderInfo {
   decryptdata: LevelKey;
@@ -92,20 +93,30 @@ export default class KeyLoader implements ComponentAPI {
     encryptedFragments: Fragment[],
   ): void | Promise<void> {
     if (this.emeController && this.config.emeEnabled) {
-      // access key-system with nearest key on start (loaidng frag is unencrypted)
-      const { sn, cc } = loadingFrag;
-      for (let i = 0; i < encryptedFragments.length; i++) {
-        const frag = encryptedFragments[i];
-        if (
-          cc <= frag.cc &&
-          (sn === 'initSegment' || frag.sn === 'initSegment' || sn < frag.sn)
-        ) {
-          this.emeController
-            .selectKeySystemFormat(frag)
-            .then((keySystemFormat) => {
-              frag.setKeyFormat(keySystemFormat);
+      // access key-system with nearest key on start (loading frag is unencrypted)
+      if (encryptedFragments.length) {
+        const { sn, cc } = loadingFrag;
+        for (let i = 0; i < encryptedFragments.length; i++) {
+          const frag = encryptedFragments[i];
+          if (
+            cc <= frag.cc &&
+            (sn === 'initSegment' || frag.sn === 'initSegment' || sn < frag.sn)
+          ) {
+            return this.emeController
+              .selectKeySystemFormat(frag)
+              .then((keySystemFormat) => {
+                frag.setKeyFormat(keySystemFormat);
+              });
+          }
+        }
+      } else if (this.config.experimentalKeySystemAccessForClearContent) {
+        const keySystemsInConfig = getKeySystemsForConfig(this.config);
+        if (keySystemsInConfig.length) {
+          return this.emeController
+            .selectKeySystem(keySystemsInConfig)
+            .then(() => {
+              /* void */
             });
-          break;
         }
       }
     }
@@ -122,18 +133,6 @@ export default class KeyLoader implements ComponentAPI {
     }
 
     return this.loadInternal(frag);
-  }
-
-  test_loadKeysBeforeFragLoad(
-    frag: Fragment,
-    keySystems: KeySystems[],
-  ): Promise<KeyLoadedData> {
-    if (this.emeController) {
-      return this.emeController
-        ?.test_selectKeySystemFromConfig(keySystems)
-        .then(() => ({ frag, keyInfo: null as any }));
-    }
-    return Promise.resolve({ frag, keyInfo: null as any });
   }
 
   loadInternal(

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -16,7 +16,7 @@ import type { KeyLoadedData } from '../types/events';
 import type { LevelKey } from './level-key';
 import type EMEController from '../controller/eme-controller';
 import type { MediaKeySessionContext } from '../controller/eme-controller';
-import type { KeySystemFormats } from '../utils/mediakeys-helper';
+import type { KeySystemFormats, KeySystems } from '../utils/mediakeys-helper';
 
 export interface KeyLoaderInfo {
   decryptdata: LevelKey;
@@ -122,6 +122,18 @@ export default class KeyLoader implements ComponentAPI {
     }
 
     return this.loadInternal(frag);
+  }
+
+  test_loadKeysBeforeFragLoad(
+    frag: Fragment,
+    keySystems: KeySystems[],
+  ): Promise<KeyLoadedData> {
+    if (this.emeController) {
+      return this.emeController
+        ?.test_selectKeySystemFromConfig(keySystems)
+        .then(() => ({ frag, keyInfo: null as any }));
+    }
+    return Promise.resolve({ frag, keyInfo: null as any });
   }
 
   loadInternal(


### PR DESCRIPTION
### This PR will...

Request key system access based on the eme configuration and block loading clear content until the media keys are set.

This resolves an issue on Chrome where if clear content is encrypted into the SourceBuffer followed by setting media keys then transitioning to encrypted content, Chrome will die with `PIPELINE_DECODE_ERROR`:
![image](https://github.com/user-attachments/assets/fb9c354a-4f44-4fa0-bc4e-49873f2bec7e)

This issue can happen either:
- If the HLS stream starts with clear content only in the manifest, and later transitions to encrypted content
- If the HLS stream starts with mixed content in the manifest, but the first buffered segment is unencrypted. This creates a race-condition today, where the first clear segment might load before the media keys could be set. This has been noticed on MediaTailor live stream with prerolls, where the prerolls were loaded from disk cache, loading faster than it took the media keys to be set.

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

https://github.com/video-dev/hls.js/issues/4230
https://github.com/video-dev/hls.js/issues/5753

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
