### PR TITLE
fix: Load video segment by CC when audio-stream-controller is stuck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hls.js",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hls.js",
-      "version": "1.5.16",
+      "version": "1.5.17",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -241,6 +241,10 @@ class AudioStreamController
                 `Waiting fragment cc (${frag.cc}) @ ${frag.start} cancelled because another fragment at ${bufferInfo.end} is needed`,
               );
               this.clearWaitingFragment();
+            } else if (this.waitingVideoCC != null) {
+              this.hls.trigger(Events.VIDEO_PTS_NEEDED, {
+                cc: waitingData.frag.cc,
+              });
             }
           }
         } else {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -34,6 +34,7 @@ import type {
   LevelsUpdatedData,
   ManifestParsedData,
   MediaAttachedData,
+  VideoPtsNeededData,
 } from '../types/events';
 
 const TICK_INTERVAL = 100; // how often to tick in ms
@@ -92,6 +93,7 @@ export default class StreamController
     hls.on(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
     hls.on(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.on(Events.FRAG_BUFFERED, this.onFragBuffered, this);
+    hls.on(Events.VIDEO_PTS_NEEDED, this.onVideoPtsNeeded, this);
   }
 
   protected _unregisterListeners() {
@@ -113,6 +115,7 @@ export default class StreamController
     hls.off(Events.BUFFER_FLUSHED, this.onBufferFlushed, this);
     hls.off(Events.LEVELS_UPDATED, this.onLevelsUpdated, this);
     hls.off(Events.FRAG_BUFFERED, this.onFragBuffered, this);
+    hls.off(Events.VIDEO_PTS_NEEDED, this.onVideoPtsNeeded, this);
   }
 
   protected onHandlerDestroying() {
@@ -347,6 +350,7 @@ export default class StreamController
       );
     }
     if (!frag) {
+      this.waitingCc = null;
       return;
     }
     if (frag.initSegment && !frag.initSegment.data && !this.bitrateTest) {
@@ -694,6 +698,13 @@ export default class StreamController
 
     // trigger handler right now
     this.tick();
+  }
+
+  private onVideoPtsNeeded(
+    _: Events.VIDEO_PTS_NEEDED,
+    data: VideoPtsNeededData,
+  ) {
+    this.waitingCc = data.cc;
   }
 
   protected _handleFragmentLoadProgress(data: FragLoadedData) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -49,6 +49,7 @@ import {
   TrackLoadingData,
   BufferFlushedData,
   SteeringManifestLoadedData,
+  VideoPtsNeededData,
 } from './types/events';
 
 export enum Events {
@@ -168,6 +169,8 @@ export enum Events {
   BACK_BUFFER_REACHED = 'hlsBackBufferReached',
   // fired after steering manifest has been loaded - data: { steeringManifest: SteeringManifest object, url: steering manifest URL }
   STEERING_MANIFEST_LOADED = 'hlsSteeringManifestLoaded',
+  // fired when audio stream controller is stuck and requires video PTS to be available for a continuity
+  VIDEO_PTS_NEEDED = 'hlsVideoPtsNeeded',
 }
 
 /**
@@ -374,6 +377,10 @@ export interface HlsListeners {
   [Events.STEERING_MANIFEST_LOADED]: (
     event: Events.STEERING_MANIFEST_LOADED,
     data: SteeringManifestLoadedData,
+  ) => void;
+  [Events.VIDEO_PTS_NEEDED]: (
+    event: Events.VIDEO_PTS_NEEDED,
+    data: VideoPtsNeededData,
   ) => void;
 }
 export interface HlsEventEmitter {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -201,6 +201,10 @@ export interface LevelPTSUpdatedData {
   end: number;
 }
 
+export interface VideoPtsNeededData {
+  cc: number;
+}
+
 export interface AudioTrackSwitchingData extends MediaPlaylist {}
 
 export interface AudioTrackSwitchedData extends MediaPlaylist {}


### PR DESCRIPTION
### This PR will...

Re-merges: https://github.com/DiceTechnology/hls.js/pull/20

### Why is this Pull Request needed?

The player goes into a deadlock because it selects the video and audio from different continuities, and is unable to locate the initPTS of the audio.

This is consistently reproducible on streams where the audio and video manifests are slightly offset, and the seek happens across continuities that the player hasn't buffered, hence it isn't yet aware of the initPTS of the audio segment.

Playing the stream without seeking doesn't cause the issue.

### Resolves issues:

https://dicetech.atlassian.net/browse/DORIS-2986