### PR TITLE
Fix/doris 3053 clear to encrypted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hls.js",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hls.js",
-      "version": "1.5.18",
+      "version": "1.5.19",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/loader/key-loader.ts
+++ b/src/loader/key-loader.ts
@@ -109,7 +109,8 @@ export default class KeyLoader implements ComponentAPI {
               });
           }
         }
-      } else if (this.config.requireKeySystemAccessOnStart) {
+      }
+      if (this.config.requireKeySystemAccessOnStart) {
         const keySystemsInConfig = getKeySystemsForConfig(this.config);
         if (keySystemsInConfig.length) {
           return this.emeController


### PR DESCRIPTION
### This PR will...

Fixes `PIPELINE_ERROR_DECODE` when transitioning from clear to encrypted content when the continuity preceeding the clear content either:
- is clear
- is encrypted but has no `EXT-X-KEY` (as it uses the key from the previous continuity)

This PR allows falling back to using the key system from the config when non of the encrypted fragments are deemed usable from the manifest.

### Why is this Pull Request needed?

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
