### PR TITLE
Fix/doris 3359 panasonic hls playback

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -4127,6 +4127,7 @@ export enum MetadataSchema {
 export type MP4RemuxerConfig = {
     stretchShortVideoTrack: boolean;
     maxAudioFramesDrift: number;
+    preventNegativeStartDts: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "NetworkComponentAPI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hls.js",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hls.js",
-      "version": "1.6.14",
+      "version": "1.6.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "license": "Apache-2.0",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "homepage": "https://github.com/video-dev/hls.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -152,6 +152,7 @@ export type LevelControllerConfig = {
 export type MP4RemuxerConfig = {
   stretchShortVideoTrack: boolean;
   maxAudioFramesDrift: number;
+  preventNegativeStartDts: boolean;
 };
 
 export interface PlaylistLoaderConstructor {
@@ -420,6 +421,7 @@ export const hlsDefaultConfig: HlsConfig = {
   fpsController: FPSController,
   stretchShortVideoTrack: false, // used by mp4-remuxer
   maxAudioFramesDrift: 1, // used by mp4-remuxer
+  preventNegativeStartDts: false, // used by mp4-remuxer
   forceKeyFrameOnDiscontinuity: true, // used by ts-demuxer
   abrEwmaFastLive: 3, // used by abr-controller
   abrEwmaSlowLive: 9, // used by abr-controller

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -814,12 +814,15 @@ export default class MP4Remuxer extends Logger implements Remuxer {
       }),
     );
     const type: SourceBufferName = 'video';
+    const startDTS = (firstDTS - initTime) / timeScale;
     const data = {
       data1: moof,
       data2: mdat,
       startPTS: (minPTS - initTime) / timeScale,
       endPTS: (maxPTS + mp4SampleDuration - initTime) / timeScale,
-      startDTS: (firstDTS - initTime) / timeScale,
+      startDTS: this.config.preventNegativeStartDts
+        ? Math.max(startDTS, 0)
+        : startDTS,
       endDTS: nextVideoTs / timeScale,
       type,
       hasAudio: false,


### PR DESCRIPTION
### This PR will...

Fixes HLS playback on Panasonic TVs.

### Why is this Pull Request needed?

Panasonic TVs cannot handle negative DTS values. Presumably because older decoders expect positive timestamps. This can cause integer overflow as signed integers/negative numbers will be treated as massive unsigned integers, causing the timestamp to jump. To the user, the video never plays, and it just "seeks" to the end.

https://dicetech.atlassian.net/browse/DORIS-3359
https://dicetech.atlassian.net/browse/UTV-4390