### PR TITLE
Apply PlayReady workaround for all Windows browsers

### DIFF
--- a/src/utils/playready-workaround.ts
+++ b/src/utils/playready-workaround.ts
@@ -19,6 +19,17 @@ import {
 } from './mp4-tools';
 import type { LevelDetails } from '../loader/level-details';
 
+function isWindows(): boolean {
+  const uaData = (navigator as { userAgentData?: { platform?: string } })
+    .userAgentData;
+  if (uaData?.platform) {
+    return uaData.platform.toLowerCase() === 'windows';
+  }
+  return (
+    !!navigator.platform && navigator.platform.toLowerCase().includes('win')
+  );
+}
+
 /**
  * Applies a PlayReady DRM workaround to level details.
  *
@@ -168,7 +179,7 @@ export function fakeEncryption(initSegment: Uint8Array) {
       // not clear why this is necessary on Xbox One, but it seems to be evidence
       // of another bug in the firmware implementation of MediaSource & EME.
       // TODO: needs more tests
-      if (navigator.userAgent.match(/Edge?\//)) {
+      if (isWindows()) {
         newEntries.push(encEntry);
         newEntries.push(entry);
       } else {
@@ -266,7 +277,7 @@ export function fakeEncryption(initSegment: Uint8Array) {
   // patched one, otherwise video element throws following error:
   // CHUNK_DEMUXER_ERROR_APPEND_FAILED: Sample encryption info is not
   // available.
-  if (navigator.userAgent.match(/Edge?\//)) {
+  if (isWindows()) {
     return appendUint8Array(modifiedInitSegment, initSegment);
   } else {
     return modifiedInitSegment;


### PR DESCRIPTION
### This PR will ensure that the PlayReady Workaround previously added for Edge will also work on Chrome / Windows

### Why is this Pull Request needed?
To make Hardware DRM work in Chrome / Windows (requires `requiresEncryptionInfoInAllInitSegments` to be set to `true`)

### Are there any points in the code the reviewer needs to double check?
other browsers might be impacted (Firefox, Opera etc)

### Resolves issues:
https://dicetech.atlassian.net/browse/DORIS-3737

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
